### PR TITLE
Created model method to handle existing cache-key generation

### DIFF
--- a/betty/cropper/api/views.py
+++ b/betty/cropper/api/views.py
@@ -104,7 +104,7 @@ def update_selection(request, image_id, ratio_slug):
         image.selections = {}
 
     image.selections[ratio_slug] = selection
-    cache.delete("image-{}".format(image.id))
+    cache.delete(image.cache_key())
     image.save()
 
     ratio_path = os.path.join(image.path(), ratio_slug)
@@ -162,7 +162,7 @@ def detail(request, image_id):
         for field in ("name", "credit", "selections"):
             if field in request_json:
                 setattr(image, field, request_json[field])
-        cache.delete("image-{}".format(image.id))
+        cache.delete(image.cache_key())
         image.save()
 
         return HttpResponse(json.dumps(image.to_native()), content_type="application/json")

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -373,3 +373,9 @@ class Image(models.Model):
             if self.selections and data['selections'][ratio] == self.selections.get(ratio):
                 data['selections'][ratio]["source"] = "user"
         return data
+
+    def cache_key(self):
+        """
+        Returns string unique to cache instance
+        """
+        return "image={}".format(self.id)


### PR DESCRIPTION
Cache key generation should be owned at the model level. Ideally any cache-delegation (delete / add / store ) should also be handled with post_safe hooks.
