### PR TITLE
DRY-ed all json.dump with little buisness value.

### DIFF
--- a/betty/cropper/api/helpers.py
+++ b/betty/cropper/api/helpers.py
@@ -1,0 +1,7 @@
+import json
+
+def message(the_word):
+    """
+    View helper. Generate full JSON respone for generic message.
+    """
+    return json.dumps({'message': the_word})

--- a/betty/cropper/api/views.py
+++ b/betty/cropper/api/views.py
@@ -14,6 +14,7 @@ from django.views.decorators.cache import never_cache
 
 from betty.conf.app import settings
 from .decorators import betty_token_auth
+from .helpers import message
 from betty.cropper.models import Image
 
 
@@ -56,7 +57,7 @@ def new(request):
 
     image_file = request.FILES.get("image")
     if image_file is None:
-        return HttpResponseBadRequest(json.dumps({'message': 'No image'}))
+        return HttpResponseBadRequest(message('No image'))
 
     image = Image.objects.create_from_path(
         image_file.temporary_file_path(),
@@ -77,14 +78,12 @@ def update_selection(request, image_id, ratio_slug):
     try:
         image = Image.objects.get(id=image_id)
     except Image.DoesNotExist:
-        message = json.dumps({"message": "No such image!"})
-        return HttpResponseNotFound(message, content_type="application/json")
+        return HttpResponseNotFound(message("No such image!"), content_type="application/json")
 
     try:
         request_json = json.loads(request.body.decode("utf-8"))
     except Exception:
-        message = json.dumps({"message": "Bad JSON"})
-        return HttpResponseBadRequest(message, content_type="application/json")
+        return HttpResponseBadRequest(message("Bad JSON"), content_type="application/json")
     try:
         selection = {
             "x0": int(request_json["x0"]),
@@ -93,12 +92,10 @@ def update_selection(request, image_id, ratio_slug):
             "y1": int(request_json["y1"]),
         }
     except (KeyError, ValueError):
-        message = json.dumps({"message": "Bad selection"})
-        return HttpResponseBadRequest(message, content_type="application/json")
+        return HttpResponseBadRequest(message("Bad selection"), content_type="application/json")
 
     if ratio_slug not in settings.BETTY_RATIOS:
-        message = json.dumps({"message": "No such ratio"})
-        return HttpResponseBadRequest(message, content_type="application/json")
+        return HttpResponseBadRequest(message("No such ratio"), content_type="application/json")
 
     if image.selections is None:
         image.selections = {}
@@ -150,14 +147,12 @@ def detail(request, image_id):
         try:
             image = Image.objects.get(id=image_id)
         except Image.DoesNotExist:
-            message = json.dumps({"message": "No such image!"})
-            return HttpResponseNotFound(message, content_type="application/json")
+            return HttpResponseNotFound(message("No such image!"), content_type="application/json")
 
         try:
             request_json = json.loads(request.body.decode("utf-8"))
         except Exception:
-            message = json.dumps({"message": "Bad Request"})
-            return HttpResponseBadRequest(message, content_type="application/json")
+            return HttpResponseBadRequest(message("Bad Request"), content_type="application/json")
 
         for field in ("name", "credit", "selections"):
             if field in request_json:
@@ -175,10 +170,9 @@ def detail(request, image_id):
             try:
                 image = Image.objects.get(id=image_id)
             except Image.DoesNotExist:
-                message = json.dumps({"message": "No such image!"})
-                return HttpResponseNotFound(message, content_type="application/json")
+                return HttpResponseNotFound(message("No such image!"), content_type="application/json")
             data = image.to_native()
-            cache.set(cache_key, data, 60 * 60)
+            cache.set(cache_key, data, 360)
 
         return HttpResponse(json.dumps(data), content_type="application/json")
 


### PR DESCRIPTION
Even more drying, I'm dying.
- Reduce human error with a helper function. Really no justification for the same copy-n-paste code.
- Why are we making do math? 60 \* 60 will always be the same.
  ### todo
- A decorator (oursomething) should be created for all the BadRequest/NotFound as they all check for the same thing.
- A lot of string are used w/ no runtime value. Give the lexer a break & create view constants. (eg."application/json")
