### PR TITLE
Fix south error with django 1.7

### DIFF
--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/betty/conf/server.py
+++ b/betty/conf/server.py
@@ -104,8 +104,13 @@ INSTALLED_APPS = (
     'betty.cropper',
     'betty.authtoken',
     'betty.image_browser',
-    'south',
 )
+
+# Only use south with django < 1.7
+import django
+if django.VERSION < (1, 7):
+    INSTALLED_APPS = INSTALLED_APPS + ('south',)
+
 
 CELERY_IGNORE_RESULT = True
 CELERY_ALWAYS_EAGER = True


### PR DESCRIPTION
This seems to fix that django 1.7 install bug by just not loading south.
