### PR TITLE
Image Lazy Loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.py[co]
 *.egg-info
 lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ python:
 - '2.7'
 - '3.2'
 - '3.3'
-env:
-- DJANGO_VERSION=1.5
-- DJANGO_VERSION=1.6
 matrix:
   allow_failures:
     - python: '3.2'
@@ -14,7 +11,6 @@ cache:
   directories:
   - "$HOME/.pip-cache/"
 install:
-- pip install django==$DJANGO_VERSION
 - pip install --download-cache $HOME/.pip-cache -r requirements-dev.txt
 script:
 - py.test tests/ --cov betty --cov-report term-missing

--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -1,160 +1,183 @@
-(function( w ){
-    /* We can request an image at every possible width, but let's limit it to a reasonable number
-       We can set these so they correspond to our more common sizes.
-    */
-    var IMAGE_URL = w.BETTY_IMAGE_URL || "{{ BETTY_IMAGE_URL }}",
-        RATIOS = {{ BETTY_RATIOS|safe }},
-        ASPECT_RATIO_TOLERANCE = .1, // 10% tolerance. 
-        breakpoints = [{{ BETTY_WIDTHS|join:","}}];
+(function(w){
+  /* We can request an image at every possible width, but let's limit it to a reasonable number
+   We can set these so they correspond to our more common sizes.
+   */
+  var IMAGE_URL = w.BETTY_IMAGE_URL || "{{ BETTY_IMAGE_URL }}",
+      RATIOS = {{ BETTY_RATIOS|safe }},
+      ASPECT_RATIO_TOLERANCE = .1, // 10% tolerance.
+      breakpoints = [{{ BETTY_WIDTHS|join:","}}];
 
-    w.picturefill = function(elements) {
-        //don't need to do them all at once. can decide to do lazy load if needed
-        if (elements instanceof Array) {
-            var ps = elements;
-        }
-        else if (elements instanceof HTMLElement) {
-            var ps = [ elements ];
-        }
-        else {
-            var ps = w.document.getElementsByTagName( "div" );
-        }
-        var imageData = [];
-        for (var i = 0, il = ps.length; i < il; i++){
-            var el = ps[i];
-            if(el.getAttribute( "data-type" ) !== "image" ){
-                continue;
-            }
-            var div = el.getElementsByTagName( "div" )[0];
-            if (el.getAttribute( "data-image-id" ) !== null ) {
-                var id = el.getAttribute( "data-image-id" ),
-                    crop = el.getAttribute( "data-crop" );
+  w.picturefill = function(elements, forceRerender) {
 
-                var id_str = "";
-                for(var ii=0; ii < id.length; ii++) {
-                    if ((ii % 4) === 0) {
-                        id_str += "/";
-                    }
-                    id_str += id.charAt(ii);
-                }
-
-                // Find any existing img element in the picture element
-                var picImg = div.getElementsByTagName( "img" )[ 0 ];
-                if(!picImg){
-                    // for performance reasons this will be added to the dom later
-                    picImg = w.document.createElement( "img" );
-                    picImg.alt = el.getAttribute( "data-alt" );
-                }
-
-                if (el.getAttribute("data-format")) {
-                    format = el.getAttribute("data-format");
-                }
-                else {
-                    format = "jpg";
-                }
-
-                if (format === "gif") {
-                    // for GIFs, we just dump out original
-                    
-                    imageData.push({
-                        'div': div,
-                        'img': picImg,
-                        'url': IMAGE_URL + id_str + "/animated/original.gif"
-                    });
-                }
-                else {
-                    // determine size & crop for PNGs & JPGs.
-                    var _w = div.offsetWidth,
-                        _h = div.offsetHeight;
-
-                    if (!crop || crop === "") {
-                        crop = computeAspectRatio(_w, _h);
-                    }
-
-                    // Scale up to the pixel ratio
-                    if (w.devicePixelRatio) {
-                      _w = Math.round(w.devicePixelRatio * _w);
-                      _h = Math.round(w.devicePixelRatio * _h);
-                    }
-
-                    var width = null;
-                    for (var j = 0; j < breakpoints.length; j++) {
-                        if (_w <= breakpoints[j]) {
-                            width = breakpoints[j];
-                            break;
-                        }
-                    }
-                    if (width === null) {
-                      width = _w;
-                    }
-
-                    // if the existing image is larger (or the same) than the one we're about to load, do not update.
-                    //however if the crop changes, we need to reload.
-                    if (width > 0) {
-                        //ie8 doesn't support natural width, always load.
-                        if (typeof picImg.naturalWidth === "undefined" || picImg.naturalWidth < width ||
-                            crop !== computeAspectRatio(picImg.naturalWidth, picImg.naturalHeight)) {
-                            var id_str = "";
-                            for(var ii=0; ii < id.length; ii++) {
-                                if ((ii % 4) === 0) {
-                                    id_str += "/";
-                                }
-                                id_str += id.charAt(ii);
-                            }
-                            var url = IMAGE_URL + id_str + "/" + crop + "/" + width + "." + format;
-
-                            imageData.push({
-                                'div': div,
-                                'img': picImg,
-                                'url': url
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        // all DOM updates should probably go here
-        for(var i = 0; i < imageData.length; i++) {
-            var data = imageData[i];
-            data.img.src = data.url;
-            if (!data.img.parentNode) {
-                data.div.appendChild(data.img);
-            }
-        }
-    };
-
-    function computeAspectRatio(_w, _h) {
-        if (_w !== 0 && _h !== 0) {
-            var aspectRatio = _w/_h;
-            for (var i in RATIOS) {
-              if (Math.abs(aspectRatio - RATIOS[i][1]) / RATIOS[i][1] < ASPECT_RATIO_TOLERANCE) {
-                return RATIOS[i][0];
-              }
-            }
-        }
-        else {
-            return "16x9"
-        }
+    // get elements to picturefill
+    var ps;
+    if (elements instanceof Array) {
+      ps = elements;
+    } else if (elements instanceof HTMLElement) {
+      ps = [elements];
+    } else {
+      ps = w.document.getElementsByTagName("div");
     }
 
-    // Run on resize and domready (w.load as a fallback)
-    if (!w.IMAGE_LISTENERS_DISABLED) {
-        if( w.addEventListener ){
-            var pictureFillTimeout;
-            w.addEventListener( "resize",
-                function() {
-                    clearTimeout(pictureFillTimeout);
-                    pictureFillTimeout = setTimeout(w.picturefill, 100);
-                }, false );
+    // loop through elements and fill them in
+    var imageData = [];
+    for (var i = 0, il = ps.length; i < il; i++){
+      var el = ps[i];
 
-            w.addEventListener( "DOMContentLoaded", function(){
-                w.picturefill();
-                // Run once only
-                w.removeEventListener( "load", w.picturefill, false );
-            }, false );
-            w.addEventListener( "load", w.picturefill, false );
+      // ensure this element is actually a image to picturefill
+      if(el.getAttribute("data-type") !== "image" ){
+        // not image to fill, skip this one
+        continue;
+      }
+
+      // check if image is in viewport for lazy loading
+      var innerHeight = w.innerHeight || w.document.documentElement.clientHeight,
+          visible = el.getBoundingClientRect().top <= innerHeight;
+
+      // this is a div to picturefill, start working on it if it hasn't been rendered yet
+      if (el.getAttribute("data-image-id") !== null
+          && visible 
+          && (forceRerender || !el.getAttribute("data-rendered"))) {
+        var imageContainer = el.getElementsByTagName("div")[0],
+            imageId = el.getAttribute("data-image-id"),
+            imageCrop = el.getAttribute("data-crop"),
+            format = el.getAttribute("data-format") || "jpg";
+
+        // construct ID path for image
+        var idStr = "";
+        for(var ii = 0; ii < imageId.length; ii++) {
+          if ((ii % 4) === 0) {
+            idStr += "/";
+          }
+          idStr += imageId.charAt(ii);
         }
-        else if( w.attachEvent ){
-            w.attachEvent( "onload", w.picturefill );
+
+        // find any existing img element in the picture element
+        var picImg = imageContainer.getElementsByTagName("img")[0];
+        if(!picImg){
+          // for performance reasons this will be added to the dom later
+          picImg = w.document.createElement("img");
+
+          var alt = el.getAttribute("data-alt");
+          if (alt) {
+            picImg.alt = alt;
+          }
         }
+
+        // determine what to do based on format
+        if (format === "gif") {
+          // for GIFs, we just dump out original
+          imageData.push({
+            'div': imageContainer,
+            'img': picImg,
+            'url': IMAGE_URL + idStr + "/animated/original.gif"
+          });
+        } else {
+          // determine size & crop for PNGs & JPGs.
+          var _w = imageContainer.offsetWidth,
+              _h = imageContainer.offsetHeight;
+
+          if (!imageCrop || imageCrop === "") {
+            imageCrop = computeAspectRatio(_w, _h);
+          }
+
+          // scale up to the pixel ratio if there's some pixel ratio defined
+          if (w.devicePixelRatio) {
+            _w = Math.round(w.devicePixelRatio * _w);
+            _h = Math.round(w.devicePixelRatio * _h);
+          }
+
+          // determine if a breakpoint width should be used, otherwise use previously defined width
+          var width = null;
+          for (var j = 0; j < breakpoints.length; j++) {
+            if (_w <= breakpoints[j]) {
+              width = breakpoints[j];
+              break;
+            }
+          }
+          if (width === null) {
+            width = _w;
+          }
+
+          // if the existing image is larger (or the same) than the one we're about to load, do not update.
+          //  however if the crop changes, we need to reload.
+          if (width > 0) {
+            //ie8 doesn't support natural width, always load.
+            if (typeof picImg.naturalWidth === "undefined" || picImg.naturalWidth < width
+                || imageCrop !== computeAspectRatio(picImg.naturalWidth, picImg.naturalHeight)) {
+              // put image in image data to render
+              imageData.push({
+                'div': imageContainer,
+                'img': picImg,
+                'url': IMAGE_URL + idStr + "/" + imageCrop + "/" + width + "." + format
+              });
+            }
+          }
+        }
+      }
     }
-}( this ));
+    // loop through image data and insert images, all DOM updates should probably go here
+    for(var i = 0; i < imageData.length; i++) {
+      var data = imageData[i];
+      data.img.src = data.url;
+      if (!data.img.parentNode) {
+        data.div.appendChild(data.img);
+        data.div.parentNode.setAttribute("data-image-rendered", "true");
+      }
+    }
+  };
+
+  /**
+   * Figure out best aspect ratio based on width, height, and given aspect ratios.
+   */
+  function computeAspectRatio(_w, _h) {
+    if (_w !== 0 && _h !== 0) {
+      var aspectRatio = _w/_h;
+      for (var i in RATIOS) {
+        if (Math.abs(aspectRatio - RATIOS[i][1]) / RATIOS[i][1] < ASPECT_RATIO_TOLERANCE) {
+          return RATIOS[i][0];
+        }
+      }
+    } else {
+      return "16x9";
+    }
+  }
+
+  function addEventListener(ele, event, callback) {
+    if (ele.addEventListener) {
+      ele.addEventListener(event, callback, false);
+    } else if (ele.attachEvent) {
+      ele.attachEvent("on" + event, callback);
+    }
+  }
+
+  function removeEventListener(ele, event, callback) {
+    if (ele.removeEventListener) {
+        ele.removeEventListener(event, callback, false);
+    } else if (ele.detachEvent) {
+        ele.detachEvent("on" + event, callback);
+    }
+  }
+
+  // Run on resize and domready (w.load as a fallback)
+  if (!w.IMAGE_LISTENERS_DISABLED) {
+
+    var pictureFillTimeout;
+    addEventListener(w, "resize", function () {
+      clearTimeout(pictureFillTimeout);
+      pictureFillTimeout = setTimeout(function () {
+        w.picturefill(null, true);
+      }, 100);
+    });
+
+    addEventListener(w, "DOMContentLoaded", function () {
+      w.picturefill();
+      removeEventListener(w, "load");
+    });
+
+    addEventListener(w, "load", w.picturefill);
+    addEventListener(w, "scroll", w.picturefill);
+
+  }
+
+}(this));


### PR DESCRIPTION
Lazy loads by attaching a picturefill listener on scroll. Only loads images when forceRerender is true, or image container does not have a value for the data-rendered attribute and user has already scrolled image into view.
