### PR TITLE
Image.js: use the same attr name for the 'rendered' flag

### DIFF
--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -152,7 +152,7 @@
       data.img.src = data.url;
       if (!data.img.parentNode) {
         data.div.appendChild(data.img);
-        data.div.parentNode.setAttribute("data-image-rendered", "true");
+        data.div.parentNode.setAttribute("data-rendered", "true");
       }
     }
   };


### PR DESCRIPTION
The related code: https://github.com/theonion/betty-cropper/blob/master/betty/cropper/templates/image.js#L66
