### PR TITLE
pausable betty cropper and limit loading images above the fold

### DIFF
--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -34,7 +34,10 @@
   }
 
   w.picturefill = function(elements, forceRerender) {
-
+    // It is sometimes desirable to scroll without loading images as we go.
+    if (w.pauseBettyCroppyPicturefill) {
+      return;
+    }
     // get elements to picturefill
     var ps;
     if (elements instanceof Array) {
@@ -57,9 +60,11 @@
       }
 
       // check if image is in viewport for lazy loading, and
-      // preload images if they're within 100px of being shown.
-      var innerHeight = w.innerHeight || w.document.documentElement.clientHeight,
-          visible = el.getBoundingClientRect().top <= (innerHeight + 250);
+      // preload images if they're within 100px of being shown above scroll,
+      // within 250px of being shown below scroll.
+      var elementRect = el.getBoundingClientRect(),
+          innerHeight = w.innerHeight || w.document.documentElement.clientHeight,
+          visible = elementRect.top <= (innerHeight + 250) && elementRect.top >= -100;
 
       // this is a div to picturefill, start working on it if it hasn't been rendered yet
       if (el.getAttribute("data-image-id") !== null


### PR DESCRIPTION
Two things here:

1)

Allows pages relying on betty cropper to completely pause Betty Cropper picturefill.

The specific reason we want this is for the reading-list. Because the reading list scrolls past a bunch of content. While this is happening we don't want to kick off any image loading.

2)

Fixes the logic for pre loading images. This now only loads images that are above 250px of the bottom of the viewport and 100px of the top of the viewport. Previously all images above the viewport would load.

Specifically we want to avoid loading images above the viewport in the reading list because it will screw up the scroll position as images come loading in above your reading position.
