### PR TITLE
Pause image loading

### DIFF
--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -34,7 +34,10 @@
   }
 
   w.picturefill = function(elements, forceRerender) {
-
+    // It is sometimes desirable to scroll without loading images as we go.
+    if (w.pauseBettyCroppyPicturefill) {
+      return;
+    }
     // get elements to picturefill
     var ps;
     if (elements instanceof Array) {
@@ -57,9 +60,11 @@
       }
 
       // check if image is in viewport for lazy loading, and
-      // preload images if they're within 100px of being shown.
-      var innerHeight = w.innerHeight || w.document.documentElement.clientHeight,
-          visible = el.getBoundingClientRect().top <= (innerHeight + 250);
+      // preload images if they're within 100px of being shown above scroll,
+      // within 250px of being shown below scroll.
+      var elementRect = el.getBoundingClientRect(),
+          innerHeight = w.innerHeight || w.document.documentElement.clientHeight,
+          visible = elementRect.top <= (innerHeight + 250) && elementRect.top >= -100;
 
       // this is a div to picturefill, start working on it if it hasn't been rendered yet
       if (el.getAttribute("data-image-id") !== null

--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -33,9 +33,9 @@
     };
   }
 
-  w.picturefill = function(elements, forceRerender) {
+  w.picturefill = function picturefill (elements, forceRerender) {
     // It is sometimes desirable to scroll without loading images as we go.
-    if (w.pauseBettyCroppyPicturefill) {
+    if (picturefill.paused()) {
       return;
     }
     // get elements to picturefill
@@ -161,6 +161,25 @@
         data.div.parentNode.setAttribute("data-rendered", "true");
       }
     }
+  };
+
+  /**
+   * picturefill pause and resume.
+   * Useful to prevent loading unneccessary images, such as when scrolling
+   * the reading list.
+   */
+  var isPaused = false;
+  picturefill.pause = function () {
+    isPaused = true;
+  };
+
+  picturefill.resume = function () {
+   isPaused = false;
+   picturefill();
+  };
+
+  picturefill.paused = function () {
+   return isPaused;
   };
 
   /**

--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -33,9 +33,9 @@
     };
   }
 
-  w.picturefill = function picturefill (elements, forceRerender) {
+  w.picturefill = function (elements, forceRerender) {
     // It is sometimes desirable to scroll without loading images as we go.
-    if (picturefill.paused()) {
+    if (w.picturefill.paused()) {
       return;
     }
     // get elements to picturefill
@@ -169,16 +169,16 @@
    * the reading list.
    */
   var isPaused = false;
-  picturefill.pause = function () {
+  w.picturefill.pause = function () {
     isPaused = true;
   };
 
-  picturefill.resume = function () {
+  w.picturefill.resume = function () {
    isPaused = false;
    picturefill();
   };
 
-  picturefill.paused = function () {
+  w.picturefill.paused = function () {
    return isPaused;
   };
 


### PR DESCRIPTION
@kand sorry for flipping pull requests on you here, but sometime last evening I renamed the branch to something more correct.

Here I've implemented `pause()`/`resume()`/`paused()` methods.

These semantics are nice as the `resume()` method can encapsulate a call to `picturefill()` so users of pause/resume won't get stuck with missing images.