### PR TITLE
Support serving multiple domains

### DIFF
--- a/betty/conf/app.py
+++ b/betty/conf/app.py
@@ -22,6 +22,7 @@ PACKAGE_DIR = os.path.dirname(os.path.dirname(__file__))
 DEFAULTS = {
     "BETTY_IMAGE_ROOT": os.path.join(_settings.MEDIA_ROOT, "images"),
     "BETTY_IMAGE_URL": urljoin(_settings.MEDIA_URL, "images/"),
+    "BETTY_IMAGE_URL_USE_REQUEST_HOST": False,
     "BETTY_RATIOS": ("1x1", "2x1", "3x1", "3x4", "4x3", "16x9"),
     "BETTY_WIDTHS": [],
     "BETTY_CLIENT_ONLY_WIDTHS": [],

--- a/betty/cropper/views.py
+++ b/betty/cropper/views.py
@@ -31,6 +31,10 @@ def image_js(request):
     # make the url protocol-relative
     url_parts = list(urllib.parse.urlparse(betty_image_url))
     url_parts[0] = ""
+    if settings.BETTY_IMAGE_URL_USE_REQUEST_HOST:
+        # Prefer requested host (allows serving against multiple domains).
+        # Make sure settings.ALLOWED_HOSTS is set to avoid spoofing.
+        url_parts[1] = request.get_host()
     betty_image_url = urllib.parse.urlunparse(url_parts)
     if betty_image_url.endswith("/"):
         betty_image_url = betty_image_url[:-1]

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -200,8 +200,18 @@ def test_non_rgb(client):
 def test_image_js(settings, client):
     settings.BETTY_WIDTHS = [100, 200]
     settings.BETTY_CLIENT_ONLY_WIDTHS = [2, 1]
+    settings.BETTY_IMAGE_URL = 'http://test.example.org/images'
     res = client.get("/images/image.js")
     assert res.status_code == 200
     assert res['Content-Type'] == 'application/javascript'
     # Sorted + appends '0' if missing
     assert res.context['BETTY_WIDTHS'] == [0, 1, 2, 100, 200]
+    assert res.context['BETTY_IMAGE_URL'] == '//test.example.org/images'
+
+
+def test_image_js_use_request_host(settings, client):
+    settings.BETTY_IMAGE_URL = 'http://test.example.org/images'
+    settings.BETTY_IMAGE_URL_USE_REQUEST_HOST = True
+    res = client.get("/images/image.js", SERVER_NAME='alt.example.org')
+    assert res.status_code == 200
+    assert res.context['BETTY_IMAGE_URL'] == '//alt.example.org/images'


### PR DESCRIPTION
This was the simplest way I could modify Betty to serve against multiple domains, without a major refactor. 

This will allow us to setup per-site image domains from our single Django test app, a step towards SSL support. 

This new behavior is OFF be default, and should only be used if ALLOWED_HOSTS restricts domains (to prevent spoofing).