### PR TITLE
Adding tests and fix for URL bug, plus pinning django dependency

### DIFF
--- a/betty/cropper/urls.py
+++ b/betty/cropper/urls.py
@@ -3,11 +3,11 @@ from django.conf.urls import patterns, url, include
 urlpatterns = patterns('betty.cropper.views',
     url(r'image\.js', "image_js"),
     url(  # noqa
-        r'^(?P<id>\d{5,})/(?P<ratio_slug>[a-z0-9]+)/(?P<width>\d+)\.(?P<extension>(jpg|png))',
+        r'^(?P<id>\d{5,})/(?P<ratio_slug>[a-z0-9]+)/(?P<width>\d+)\.(?P<extension>(jpg|png))$',
         'redirect_crop'
     ),
     url(  # noqa
-        r'^(?P<id>[0-9/]+)/(?P<ratio_slug>[a-z0-9]+)/(?P<width>\d+)\.(?P<extension>(jpg|png))',
+        r'^(?P<id>[0-9/]+)/(?P<ratio_slug>[a-z0-9]+)/(?P<width>\d+)\.(?P<extension>(jpg|png))$',
         'crop'
     ),
     url(r'api/', include("betty.cropper.api.urls")),

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requires = [
 ]
 
 install_requires = [
-    "Django>=1.7",
+    "Django>=1.7,<1.9",
     "six==1.9.0",
     "slimit==0.8.1",
     "jsonfield==0.9.20",

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -94,6 +94,9 @@ def test_bad_extension(client):
     res = client.get('/images/666/1x1/500.gif')
     assert res.status_code == 404
 
+    res = client.get('/images/666/1x1/500.pngbutts')
+    assert res.status_code == 404
+
 
 def test_too_large(client):
     res = client.get("/images/666/1x1/{}.jpg".format(settings.BETTY_MAX_WIDTH + 1))


### PR DESCRIPTION
Turns out that the URL regexes are dumb, so it allows stuff like: http://i.onionstatic.com/clickhole/2307/6/16x9/1280.jpgbutts

I have fixed that. Also, it turns out that logan isn't compatible with Django 1.9, so I went ahead and pinned betty to <1.9.

:kiss: :kiss: miss you guys

