### PR TITLE
Storage refactor

### DIFF
--- a/betty/conf/app.py
+++ b/betty/conf/app.py
@@ -48,6 +48,7 @@ DEFAULTS = {
     "BETTY_DEFAULT_JPEG_QUALITY": 80,
     "BETTY_JPEG_MAX_ERROR": 3.5,
     "BETTY_JPEG_QUALITY_RANGE": None,
+    "BETTY_SAVE_CROPS": True,  # On by default (per legacy behavior)
 }
 
 

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -292,7 +292,7 @@ class Image(models.Model):
                         settings.BETTY_CACHE_FLUSHER(full_url)
 
                 if settings.BETTY_SAVE_CROPS:
-                shutil.rmtree(ratio_path)
+                    shutil.rmtree(ratio_path)
 
     def get_jpeg_quality(self, width):
         quality = None
@@ -359,17 +359,17 @@ class Image(models.Model):
             pillow_kwargs["icc_profile"] = icc_profile
 
         if settings.BETTY_SAVE_CROPS:
-        if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
-            ratio_dir = os.path.join(self.path(), ratio.string)
-            # We only want to save this to the filesystem if it's one of our usual widths.
-            try:
-                os.makedirs(ratio_dir)
-            except OSError as e:
+            if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
+                ratio_dir = os.path.join(self.path(), ratio.string)
+                # We only want to save this to the filesystem if it's one of our usual widths.
+                try:
+                    os.makedirs(ratio_dir)
+                except OSError as e:
                     if e.errno != errno.EEXIST:
-                    raise e
+                        raise e
 
-            with open(os.path.join(ratio_dir, "%d.%s" % (width, extension)), 'wb+') as out:
-                img.save(out, **pillow_kwargs)
+                with open(os.path.join(ratio_dir, "%d.%s" % (width, extension)), 'wb+') as out:
+                    img.save(out, **pillow_kwargs)
 
         tmp = io.BytesIO()
         img.save(tmp, **pillow_kwargs)

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -363,7 +363,7 @@ class Image(models.Model):
             try:
                 os.makedirs(ratio_dir)
             except OSError as e:
-                if e.errno != 17:
+                    if e.errno != errno.EEXIST:
                     raise e
 
             with open(os.path.join(ratio_dir, "%d.%s" % (width, extension)), 'wb+') as out:

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -291,6 +291,7 @@ class Image(models.Model):
                         full_url = self.get_absolute_url(ratio=ratio, width=width, format=format)
                         settings.BETTY_CACHE_FLUSHER(full_url)
 
+                if settings.BETTY_SAVE_CROPS:
                 shutil.rmtree(ratio_path)
 
     def get_jpeg_quality(self, width):
@@ -357,6 +358,7 @@ class Image(models.Model):
         if icc_profile:
             pillow_kwargs["icc_profile"] = icc_profile
 
+        if settings.BETTY_SAVE_CROPS:
         if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
             ratio_dir = os.path.join(self.path(), ratio.string)
             # We only want to save this to the filesystem if it's one of our usual widths.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,6 @@ import shutil
 from mock import patch
 import pytest
 
-from django.test import override_settings
-
 from betty.conf.app import settings
 from betty.cropper.models import Image
 
@@ -125,8 +123,9 @@ def test_image_selection_source(admin_client):
 
 
 @pytest.mark.django_db
-@override_settings(BETTY_SAVE_CROPS=True)
-def test_crop_clearing_enable_save_crops(admin_client):
+def test_crop_clearing_enable_save_crops(admin_client, settings):
+    settings.BETTY_SAVE_CROPS = True
+
     response_json = create_test_image(admin_client)
     image_id = response_json['id']
 
@@ -160,8 +159,9 @@ def test_crop_clearing_enable_save_crops(admin_client):
 
 
 @pytest.mark.django_db
-@override_settings(BETTY_SAVE_CROPS=False)
-def test_crop_clearing_disable_save_crops(admin_client):
+def test_crop_clearing_disable_save_crops(admin_client, settings):
+
+    settings.BETTY_SAVE_CROPS = False
 
     response_json = create_test_image(admin_client)
     image_id = response_json['id']
@@ -176,8 +176,8 @@ def test_crop_clearing_disable_save_crops(admin_client):
 
 
 @pytest.mark.django_db
-@override_settings(BETTY_SAVE_CROPS=True)
-def test_image_delete(admin_client):
+def test_image_delete(admin_client, settings):
+    settings.BETTY_SAVE_CROPS = True
     image = Image.objects.create(name="Testing", width=512, height=512)
     path = image.path()  # Save path before deletion
 


### PR DESCRIPTION
Goal: Allow multiple betty servers to generate crops from S3-backed storage. 

- [x] Optionally disable writing cropped image files to disk
- [ ] Allow storing of original images in S3
- [ ] Support migration from disk to S3 (TBD)
