### PR TITLE
Cleanup testing (part of storage refactor)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,19 @@
+import shutil
+
+import pytest
 from logan.runner import configure_app
+
 
 configure_app(
     project="betty",
     default_settings="betty.conf.server",
     config_path="./tests/betty.testconf.py"
 )
+
+
+@pytest.fixture()
+def clean_image_root(request):
+    """Delete all image files created during testing"""
+
+    from betty.conf.app import settings
+    shutil.rmtree(settings.BETTY_IMAGE_ROOT, ignore_errors=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,5 @@
 import os
 import json
-import shutil
 
 from mock import patch
 import pytest
@@ -28,15 +27,22 @@ def test_no_api_key(client):
     assert res.status_code == 403
 
 
-@pytest.mark.django_db
-def test_image_upload(admin_client):
-
+def create_test_image(admin_client):
     lenna_path = os.path.join(TEST_DATA_PATH, 'Lenna.png')
     with open(lenna_path, "rb") as lenna:
         data = {"image": lenna, "name": "LENNA DOT PNG", "credit": "Playboy"}
         res = admin_client.post('/images/api/new', data)
     assert res.status_code == 200
-    response_json = json.loads(res.content.decode("utf-8"))
+
+    return json.loads(res.content.decode("utf-8"))
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_image_upload(admin_client):
+
+    response_json = create_test_image(admin_client)
+
     del response_json["selections"]  # We don't care about selections in this test
     assert response_json == {
         "id": 1,
@@ -117,14 +123,10 @@ def test_image_selection_source(admin_client):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_crop_clearing(admin_client):
-    lenna_path = os.path.join(TEST_DATA_PATH, 'Lenna.png')
-    with open(lenna_path, "rb") as lenna:
-        data = {"image": lenna, "name": "LENNA DOT PNG", "credit": "Playboy"}
-        res = admin_client.post('/images/api/new', data)
-    assert res.status_code == 200
 
-    response_json = json.loads(res.content.decode("utf-8"))
+    response_json = create_test_image(admin_client)
     image_id = response_json['id']
 
     # Now let's generate a couple crops
@@ -157,23 +159,23 @@ def test_crop_clearing(admin_client):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_image_delete(admin_client):
-    image = Image.objects.create(name="Testing", width=512, height=512)
-    path = image.path()  # Save path before deletion
 
-    res = admin_client.get("/images/api/{0}".format(image.id))
-    assert res.status_code == 200
+    resp_json = create_test_image(admin_client)
+    image_id = resp_json['id']
 
-    with patch('betty.cropper.models.settings.BETTY_CACHE_FLUSHER') as mock_flusher:
+    with patch.object(Image, 'clear_crops') as mock_clear_crops:
         with patch('shutil.rmtree') as mock_rmtree:
             res = admin_client.post(
-                "/images/api/{0}".format(image.id),
+                "/images/api/{0}".format(image_id),
                 content_type="application/json",
                 REQUEST_METHOD="DELETE",
             )
             assert res.status_code == 200
-            assert not Image.objects.filter(id=image.id)
-            mock_flusher.assert_called_with('/images/1/16x9/640.png')
+            assert not Image.objects.filter(id=image_id)
+            assert mock_clear_crops.called
+            path = os.path.join(settings.BETTY_IMAGE_ROOT, str(image_id))
             mock_rmtree.assert_called_with(path, ignore_errors=True)
 
 
@@ -216,16 +218,12 @@ def test_image_search(admin_client):
     assert results["results"][0]["id"] == image.id
 
 
+@pytest.mark.usefixtures("clean_image_root")
 def test_bad_image_data(admin_client):
-    shutil.rmtree(settings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
-    lenna_path = os.path.join(TEST_DATA_PATH, 'Lenna.png')
-    with open(lenna_path, "rb") as lenna:
-        res = admin_client.post('/images/api/new', {"image": lenna})
+    response_json = create_test_image(admin_client)
 
-    assert res.status_code == 200
-    response_json = json.loads(res.content.decode("utf-8"))
-    assert response_json.get("name") == "Lenna.png"
+    assert response_json.get("name") == "LENNA DOT PNG"
     assert response_json.get("width") == 512
     assert response_json.get("height") == 512
 

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 import pytest
 
@@ -138,8 +137,8 @@ def test_missing_file(client):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_image_save(client):
-    shutil.rmtree(settings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     image = Image.objects.create(
         name="Lenna.png",
@@ -175,8 +174,8 @@ def test_image_save(client):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_non_rgb(client):
-    shutil.rmtree(settings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     image = Image.objects.create(
         name="animated.gif",

--- a/tests/test_image_files.py
+++ b/tests/test_image_files.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import stat
 
 from PIL import Image as PILImage
@@ -14,8 +13,8 @@ TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'images')
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_png():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "Lenna.png")
     image = Image.objects.create_from_path(path)
@@ -29,14 +28,15 @@ def test_png():
     assert image.jpeg_quality is None
     assert os.path.exists(image.optimized.path)
     assert os.path.exists(image.source.path)
+    assert not image.animated
 
     # Since this image is 512x512, it shouldn't end up getting changed by the optimization process
     assert os.stat(image.optimized.path).st_size == os.stat(image.source.path).st_size
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_jpeg():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "Sam_Hat1.jpg")
     image = Image.objects.create_from_path(path)
@@ -50,6 +50,7 @@ def test_jpeg():
     assert image.jpeg_quality is None
     assert os.path.exists(image.optimized.path)
     assert os.path.exists(image.source.path)
+    assert not image.animated
 
     source = PILImage.open(image.source.path)
     optimized = PILImage.open(image.optimized.path)
@@ -59,8 +60,8 @@ def test_jpeg():
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_jpeg_noext():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "Sam_Hat1_noext")
     image = Image.objects.create_from_path(path)
@@ -74,6 +75,7 @@ def test_jpeg_noext():
     assert image.jpeg_quality is None
     assert os.path.exists(image.optimized.path)
     assert os.path.exists(image.source.path)
+    assert not image.animated
 
     source = PILImage.open(image.source.path)
     optimized = PILImage.open(image.optimized.path)
@@ -84,8 +86,8 @@ def test_jpeg_noext():
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_huge_jpeg():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "huge.jpg")
     image = Image.objects.create_from_path(path)
@@ -99,6 +101,7 @@ def test_huge_jpeg():
     assert image.jpeg_quality is None
     assert os.path.exists(image.optimized.path)
     assert os.path.exists(image.source.path)
+    assert not image.animated
 
     assert image.to_native()["width"] == 3200
 
@@ -108,8 +111,8 @@ def test_huge_jpeg():
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_l_mode():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "Header-Just_How.jpg")
     image = Image.objects.create_from_path(path)
@@ -123,11 +126,12 @@ def test_l_mode():
     assert image.jpeg_quality is None
     assert os.path.exists(image.optimized.path)
     assert os.path.exists(image.source.path)
+    assert not image.animated
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_fucked_up_quant_tables():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "tumblr.jpg")
     image = Image.objects.create_from_path(path)
@@ -141,8 +145,8 @@ def test_fucked_up_quant_tables():
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_gif_upload():
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     path = os.path.join(TEST_DATA_PATH, "animated.gif")
     image = Image.objects.create_from_path(path)
@@ -155,6 +159,7 @@ def test_gif_upload():
     assert os.path.exists(image.path())
     assert os.path.exists(image.source.path)
     assert os.path.basename(image.source.path) == "animated.gif"
+    assert image.animated
 
     original_gif = os.path.join(image.path(), "animated/original.gif")
 

--- a/tests/test_imgmin.py
+++ b/tests/test_imgmin.py
@@ -1,9 +1,7 @@
 import os
 import psutil
-import shutil
 
 from betty.cropper.models import Image
-from betty.conf.app import settings as bettysettings
 
 import pytest
 
@@ -20,8 +18,8 @@ def get_open_files(process):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_imgmin_upload(settings):
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     settings.BETTY_JPEG_QUALITY_RANGE = (60, 92)
 
@@ -39,8 +37,8 @@ def test_imgmin_upload(settings):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_imgmin_cartoon(settings):
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     settings.BETTY_JPEG_QUALITY_RANGE = (60, 92)
 
@@ -62,8 +60,8 @@ def test_imgmin_cartoon(settings):
 
 
 @pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
 def test_imgmin_upload_lowquality(settings):
-    shutil.rmtree(bettysettings.BETTY_IMAGE_ROOT, ignore_errors=True)
 
     settings.BETTY_JPEG_QUALITY_RANGE = (60, 92)
 


### PR DESCRIPTION
Breaking this out from storage refactor PR https://github.com/theonion/betty-cropper/pull/56

Simplify tests by using common fixtures + image creation logic.

@MichaelButkovic @benghaziboy 