### PR TITLE
Optional save crops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Betty Cropper Change Log
+
+## Development
+
+- Added `BETTY_SAVE_CROPS_TO_DISK` boolean setting (default == True) to optionally disable writing crops to local disk

--- a/betty/conf/app.py
+++ b/betty/conf/app.py
@@ -48,6 +48,7 @@ DEFAULTS = {
     "BETTY_DEFAULT_JPEG_QUALITY": 80,
     "BETTY_JPEG_MAX_ERROR": 3.5,
     "BETTY_JPEG_QUALITY_RANGE": None,
+    "BETTY_SAVE_CROPS": True,  # On by default (per legacy behavior)
 }
 
 

--- a/betty/conf/app.py
+++ b/betty/conf/app.py
@@ -48,7 +48,7 @@ DEFAULTS = {
     "BETTY_DEFAULT_JPEG_QUALITY": 80,
     "BETTY_JPEG_MAX_ERROR": 3.5,
     "BETTY_JPEG_QUALITY_RANGE": None,
-    "BETTY_SAVE_CROPS": True,  # On by default (per legacy behavior)
+    "BETTY_SAVE_CROPS_TO_DISK": True,  # On by default (per legacy behavior)
 }
 
 

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -282,16 +282,17 @@ class Image(models.Model):
             ratios.append("original")
 
         for ratio_slug in ratios:
-            ratio_path = os.path.join(self.path(), ratio_slug)
-            if os.path.exists(ratio_path):
-                if settings.BETTY_CACHE_FLUSHER:
-                    for crop in os.listdir(ratio_path):
-                        width, format = crop.split(".")
-                        ratio = os.path.basename(ratio_path)
-                        full_url = self.get_absolute_url(ratio=ratio, width=width, format=format)
-                        settings.BETTY_CACHE_FLUSHER(full_url)
+            if settings.BETTY_CACHE_FLUSHER:
+                # TODO: BETTY_CACHE_FLUSHER should support wildcards
+                for width in settings.BETTY_WIDTHS:
+                    for format in ['png', 'jpg']:
+                        url = self.get_absolute_url(ratio=ratio_slug, width=width, format=format)
+                        settings.BETTY_CACHE_FLUSHER(url)
 
-                if settings.BETTY_SAVE_CROPS:
+            # Delete entire crop ratio directory
+            if settings.BETTY_SAVE_CROPS:
+                ratio_path = os.path.join(self.path(), ratio_slug)
+                if os.path.exists(ratio_path):
                     shutil.rmtree(ratio_path)
 
     def get_jpeg_quality(self, width):

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -292,7 +292,7 @@ class Image(models.Model):
                         settings.BETTY_CACHE_FLUSHER(full_url)
 
                 if settings.BETTY_SAVE_CROPS:
-                shutil.rmtree(ratio_path)
+                    shutil.rmtree(ratio_path)
 
     def get_jpeg_quality(self, width):
         quality = None
@@ -359,17 +359,17 @@ class Image(models.Model):
             pillow_kwargs["icc_profile"] = icc_profile
 
         if settings.BETTY_SAVE_CROPS:
-        if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
-            ratio_dir = os.path.join(self.path(), ratio.string)
-            # We only want to save this to the filesystem if it's one of our usual widths.
-            try:
-                os.makedirs(ratio_dir)
-            except OSError as e:
+            if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
+                ratio_dir = os.path.join(self.path(), ratio.string)
+                # We only want to save this to the filesystem if it's one of our usual widths.
+                try:
+                    os.makedirs(ratio_dir)
+                except OSError as e:
                     if e.errno != errno.EEXIST:
-                    raise e
+                        raise e
 
-            with open(os.path.join(ratio_dir, "%d.%s" % (width, extension)), 'wb+') as out:
-                img.save(out, **pillow_kwargs)
+                with open(os.path.join(ratio_dir, "%d.%s" % (width, extension)), 'wb+') as out:
+                    img.save(out, **pillow_kwargs)
 
         tmp = io.BytesIO()
         img.save(tmp, **pillow_kwargs)

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -363,7 +363,7 @@ class Image(models.Model):
             try:
                 os.makedirs(ratio_dir)
             except OSError as e:
-                if e.errno != 17:
+                    if e.errno != errno.EEXIST:
                     raise e
 
             with open(os.path.join(ratio_dir, "%d.%s" % (width, extension)), 'wb+') as out:

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -283,9 +283,11 @@ class Image(models.Model):
 
         for ratio_slug in ratios:
             if settings.BETTY_CACHE_FLUSHER:
+                # Since might now know which formats to flush (since maybe not saving crops to
+                # disk), need to flush all possible crops.
                 # TODO: BETTY_CACHE_FLUSHER should support wildcards
                 for width in settings.BETTY_WIDTHS:
-                    for format in ['png', 'jpg']:
+                    for format in ["png", "jpg"]:
                         url = self.get_absolute_url(ratio=ratio_slug, width=width, format=format)
                         settings.BETTY_CACHE_FLUSHER(url)
 

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -291,6 +291,7 @@ class Image(models.Model):
                         full_url = self.get_absolute_url(ratio=ratio, width=width, format=format)
                         settings.BETTY_CACHE_FLUSHER(full_url)
 
+                if settings.BETTY_SAVE_CROPS:
                 shutil.rmtree(ratio_path)
 
     def get_jpeg_quality(self, width):
@@ -357,6 +358,7 @@ class Image(models.Model):
         if icc_profile:
             pillow_kwargs["icc_profile"] = icc_profile
 
+        if settings.BETTY_SAVE_CROPS:
         if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
             ratio_dir = os.path.join(self.path(), ratio.string)
             # We only want to save this to the filesystem if it's one of our usual widths.

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -292,7 +292,7 @@ class Image(models.Model):
                         settings.BETTY_CACHE_FLUSHER(url)
 
             # Delete entire crop ratio directory
-            if settings.BETTY_SAVE_CROPS:
+            if settings.BETTY_SAVE_CROPS_TO_DISK:
                 ratio_path = os.path.join(self.path(), ratio_slug)
                 if os.path.exists(ratio_path):
                     shutil.rmtree(ratio_path)
@@ -361,7 +361,7 @@ class Image(models.Model):
         if icc_profile:
             pillow_kwargs["icc_profile"] = icc_profile
 
-        if settings.BETTY_SAVE_CROPS:
+        if settings.BETTY_SAVE_CROPS_TO_DISK:
             if width in settings.BETTY_WIDTHS or len(settings.BETTY_WIDTHS) == 0:
                 ratio_dir = os.path.join(self.path(), ratio.string)
                 # We only want to save this to the filesystem if it's one of our usual widths.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,8 +5,6 @@ import shutil
 from mock import patch
 import pytest
 
-from django.test import override_settings
-
 from betty.conf.app import settings
 from betty.cropper.models import Image
 
@@ -125,8 +123,9 @@ def test_image_selection_source(admin_client):
 
 
 @pytest.mark.django_db
-@override_settings(BETTY_SAVE_CROPS=True)
-def test_crop_clearing_enable_save_crops(admin_client):
+def test_crop_clearing_enable_save_crops(admin_client, settings):
+    settings.BETTY_SAVE_CROPS = True
+
     response_json = create_test_image(admin_client)
     image_id = response_json['id']
 
@@ -160,8 +159,9 @@ def test_crop_clearing_enable_save_crops(admin_client):
 
 
 @pytest.mark.django_db
-@override_settings(BETTY_SAVE_CROPS=False)
-def test_crop_clearing_disable_save_crops(admin_client):
+def test_crop_clearing_disable_save_crops(admin_client, settings):
+
+    settings.BETTY_SAVE_CROPS = False
 
     response_json = create_test_image(admin_client)
     image_id = response_json['id']
@@ -176,8 +176,8 @@ def test_crop_clearing_disable_save_crops(admin_client):
 
 
 @pytest.mark.django_db
-@override_settings(BETTY_SAVE_CROPS=True)
-def test_image_delete(admin_client):
+def test_image_delete(admin_client, settings):
+    settings.BETTY_SAVE_CROPS = True
     image = Image.objects.create(name="Testing", width=512, height=512)
     path = image.path()  # Save path before deletion
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from mock import call, patch
+from mock import patch
 import pytest
 
 from betty.conf.app import settings
@@ -241,8 +241,3 @@ def test_bad_image_data(admin_client):
         id_string += char
     res = admin_client.get('/images/{0}/1x1/400.jpg'.format(id_string))
     assert res.status_code == 200
-
-
-def test_clear_crops(admin_client):
-    image = Image.objects.create(name="Testing", width=512, height=512)
-    image.clear_crops()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,7 +124,7 @@ def test_image_selection_source(admin_client):
 
 @pytest.mark.django_db
 def test_crop_clearing_enable_save_crops(admin_client, settings):
-    settings.BETTY_SAVE_CROPS = True
+    settings.BETTY_SAVE_CROPS_TO_DISK = True
 
     response_json = create_test_image(admin_client)
     image_id = response_json['id']

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -176,7 +176,7 @@ def test_image_save(client):
 @pytest.mark.django_db
 @pytest.mark.usefixtures("clean_image_root")
 def test_disable_crop_save(client, settings):
-    settings.BETTY_SAVE_CROPS = False
+    settings.BETTY_SAVE_CROPS_TO_DISK = False
 
     image = Image.objects.create(
         name="Lenna.png",

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -1,0 +1,89 @@
+import os
+
+from mock import call, patch
+import pytest
+
+from django.core.files import File
+
+from betty.cropper.models import Image, Ratio
+
+
+TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'images')
+
+
+def make_some_crops(settings):
+
+    settings.BETTY_RATIOS = ["1x1", "3x1", "16x9"]
+    settings.BETTY_WIDTHS = [200, 400]
+
+    image = Image.objects.create(name="Testing", width=512, height=512)
+    lenna_path = os.path.join(TEST_DATA_PATH, 'Lenna.png')
+    with open(lenna_path, "rb") as lenna:
+        image.source.save('Lenna', File(lenna))
+
+    # Crops that would be saved (if enabled)
+    image.crop(ratio=Ratio('1x1'), width=200, extension='png')
+    image.crop(ratio=Ratio('16x9'), width=400, extension='jpg')
+    # Not saved to disk (not in WIDTH list)
+    image.crop(ratio=Ratio('16x9'), width=401, extension='jpg')
+
+    return image
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_image_clear_crops_save_disabled(settings):
+
+    settings.BETTY_SAVE_CROPS = False
+
+    image = make_some_crops(settings)
+
+    with patch('betty.cropper.models.settings.BETTY_CACHE_FLUSHER') as mock_flusher:
+        with patch('shutil.rmtree') as mock_rmtree:
+
+            image.clear_crops()
+
+            # Flushes all supported widths (until BETTY_CACHE_FLUSHER supports wildcards)
+            assert sorted(mock_flusher.call_args_list) == sorted(
+                call('/images/{image_id}/{ratio}/{width}.{extension}'.format(image_id=image.id,
+                                                                             width=width,
+                                                                             ratio=ratio,
+                                                                             extension=extension))
+                for extension in ['png', 'jpg']
+                for width in [200, 400]
+                for ratio in ['1x1', '3x1', '16x9', 'original']
+            )
+
+            # No filesystem deletes (save disabled)
+            assert not mock_rmtree.called
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_image_clear_crops_save_enabled(settings):
+
+    settings.BETTY_SAVE_CROPS = True
+
+    image = make_some_crops(settings)
+
+    with patch('betty.cropper.models.settings.BETTY_CACHE_FLUSHER') as mock_flusher:
+        with patch('shutil.rmtree') as mock_rmtree:
+
+            image.clear_crops()
+
+            # Flushes all supported widths (until BETTY_CACHE_FLUSHER supports wildcards)
+            assert sorted(mock_flusher.call_args_list) == sorted(
+                call('/images/{image_id}/{ratio}/{width}.{extension}'.format(image_id=image.id,
+                                                                             width=width,
+                                                                             ratio=ratio,
+                                                                             extension=extension))
+                for extension in ['png', 'jpg']
+                for width in [200, 400]
+                for ratio in ['1x1', '3x1', '16x9', 'original']
+            )
+
+            # Filesystem deletes entire directories if they exist
+            image_dir = os.path.join(settings.MEDIA_ROOT, 'images', str(image.id))
+            assert sorted(mock_rmtree.call_args_list) == sorted(
+                [call(os.path.join(image_dir, '1x1')),
+                 call(os.path.join(image_dir, '16x9'))])

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -34,7 +34,7 @@ def make_some_crops(settings):
 @pytest.mark.usefixtures("clean_image_root")
 def test_image_clear_crops_save_disabled(settings):
 
-    settings.BETTY_SAVE_CROPS = False
+    settings.BETTY_SAVE_CROPS_TO_DISK = False
 
     image = make_some_crops(settings)
 
@@ -62,7 +62,7 @@ def test_image_clear_crops_save_disabled(settings):
 @pytest.mark.usefixtures("clean_image_root")
 def test_image_clear_crops_save_enabled(settings):
 
-    settings.BETTY_SAVE_CROPS = True
+    settings.BETTY_SAVE_CROPS_TO_DISK = True
 
     image = make_some_crops(settings)
 


### PR DESCRIPTION
Broke this PR out of larger betty storage refactor: https://github.com/theonion/betty-cropper/pull/56

This makes writing cached files to local disk optional, as legacy behavior always wrote to disk, but in the future we are going to test with this disabled (and always generate crops on the fly).

I opted to go with a simple `BETTY_SAVE_CROPS` boolean flag as opposed to implementing a Django Storage API interface, b/c simpler approach was easiest way to test this behavior in production. Should we decide to store crops to a location other than local filesystem (such as S3) this can be swapped out, but would need to solve some challenges like ensuring we delete entire (S3) crop ratio directory on clear. 

(Note: We will fully leverage Django Storage API for the actual source image in a future PR). 

@MichaelButkovic @benghaziboy @spra85 