### PR TITLE
Change storage root option format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Betty Cropper Change Log
 
+## Version 2.0.3
+
+- Management command `change_storage_root` uses older option format for compatibility with Django 1.7
+
 ## Version 2.0.2
 
 - Added `settings.BETTY_CACHE_CROP_SEC` to allow configurable crop (and animated) cache times. Defaults to original `300` seconds.

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"

--- a/betty/cropper/management/commands/change_storage_root.py
+++ b/betty/cropper/management/commands/change_storage_root.py
@@ -1,3 +1,5 @@
+from optparse import make_option
+
 from django.core.management.base import BaseCommand
 
 from betty.cropper.models import Image
@@ -6,14 +8,39 @@ from betty.cropper.models import Image
 class Command(BaseCommand):
     help = 'Change root path for Image file fields'
 
-    def add_arguments(self, parser):
-        parser.add_argument('--check', action='store_true', help='Dry-run (read-only) check mode')
-        parser.add_argument('--old', required=True, help='Old root path (ex: /var/betty-cropper)')
-        parser.add_argument('--new', required=True, help='New root path (ex: /testing/)')
+    # This needs to run on Django 1.7
+    option_list = BaseCommand.option_list + (
+        make_option('--check',
+                    action='store_true',
+                    dest='check',
+                    default=False,
+                    help='Dry-run (read-only) check mode'),
+        make_option('--old',
+                    dest='old',
+                    help='Old root path (ex: /var/betty-cropper/)'),
+        make_option('--new',
+                    dest='new',
+                    help='New root path (ex: /testing/)'),
+    )
+
+    # This only works on Django 1.8+
+    # def add_arguments(self, parser):
+    #     parser.add_argument('--check', action='store_true', help='')
+    #     parser.add_argument('--old', required=True, help='Old root path (ex: /var/betty-cropper)')
+    #     parser.add_argument('--new', required=True, help='New root path (ex: /testing/)')
 
     def handle(self, *args, **options):
+
+        if not options['old']:
+            raise Exception('Old root not provided')
+
+        if not options['new']:
+            raise Exception('New root not provided')
+
         # Sanity check: Make sure same separator ending
         assert options['old'].endswith('/') == options['new'].endswith('/')
+
+        self.stdout.write('Checking {} images...'.format(Image.objects.count()))
 
         for image in Image.objects.iterator():
 


### PR DESCRIPTION
Production Betty servers are using Django 1.7.x, which requires an older options format. 

@MichaelButkovic @benghaziboy 