### PR TITLE
Allow longer cache times for ImageJS + crop redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Betty Cropper Change Log
 
+## Version 2.0.6
+
+- Allow configurable "Image JS" cache time via `settings.BETTY_CACHE_IMAGEJS_SEC`. ImageJS requests are cheap but make up over 50% of current production requests, and only rarely changes on deploys.
+- Increase (rarely called) "crop redireect" cache times to 1 hour, a good balance good balance between fewer requests and not overcommitting in case this ever changes.
+
 ## Version 2.0.5
 
 - Fixes max-width resize regression for cases other than "JPG mode=RGB". Switch to IO buffers requires passing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 2.0.6
 
 - Allow configurable "Image JS" cache time via `settings.BETTY_CACHE_IMAGEJS_SEC`. ImageJS requests are cheap but make up over 50% of current production requests, and only rarely changes on deploys.
-- Increase (rarely called) "crop redireect" cache times to 1 hour, a good balance good balance between fewer requests and not overcommitting in case this ever changes.
+- Increase (rarely called) "crop redireect" cache times to 1 hour, a good balance between fewer requests and not overcommitting in case this ever changes.
 
 ## Version 2.0.5
 

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.0.5"
+__version__ = "2.0.6"

--- a/betty/conf/app.py
+++ b/betty/conf/app.py
@@ -51,6 +51,7 @@ DEFAULTS = {
     "BETTY_SAVE_CROPS_TO_DISK": True,  # On by default (per legacy behavior)
     "BETTY_SAVE_CROPS_TO_DISK_ROOT": None,   # If not set, will use BETTY_IMAGE_ROOT
     "BETTY_CACHE_CROP_SEC": 300,
+    "BETTY_CACHE_IMAGEJS_SEC": 300,
 }
 
 

--- a/betty/cropper/views.py
+++ b/betty/cropper/views.py
@@ -28,7 +28,7 @@ EXTENSION_MAP = {
 }
 
 
-@cache_control(max_age=300)
+@cache_control(max_age=settings.BETTY_CACHE_IMAGEJS_SEC)
 def image_js(request):
     widths = set(settings.BETTY_WIDTHS + settings.BETTY_CLIENT_ONLY_WIDTHS)
     # Ensure '0' always present
@@ -61,7 +61,7 @@ def image_js(request):
     return render(request, "image.js", context, content_type="application/javascript")
 
 
-@cache_control(max_age=300)
+@cache_control(max_age=(60 * 60))
 def redirect_crop(request, id, ratio_slug, width, extension):
     image_id = int(id.replace("/", ""))
 


### PR DESCRIPTION
Significantly reduces betty server request counts (ImageJS file requests are 50%+ of total, but rarely change). Granted these requests are cheap, but will be an easy win to 3x cache times. 

@MichaelButkovic @benghaziboy 