### PR TITLE
Clear crops now also clears animated files/crops.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - `BETTY_CACHE_FLUSHER` can either be set to a callable object or a string import path
   - Flusher now passed list of string URLS instead of individual strings. This allows for more efficient callback batching logic.
   - Added reference cache flusher `betty.contrib.cacheflush.cachemaster`
+  - `Image.clear_crops()` now includes animated files (`.../animated/original.{gif,jpg}`)
 
 ## Version 2.0.6
 

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -324,11 +324,15 @@ class Image(models.Model):
                 paths += [self.get_absolute_url(ratio=ratio_slug, width=width, format=format)
                           for format in ["png", "jpg"]
                           for width in settings.BETTY_WIDTHS]
+            if self.animated:
+                for format in ['gif', 'jpg']:
+                    paths.append(self.get_animated_url(format=format))
+
             flusher(paths)
 
         # Optional disk crops support
         if settings.BETTY_SAVE_CROPS_TO_DISK:
-            for ratio_slug in ratios:
+            for ratio_slug in (ratios + ['animated']):
                 ratio_path = os.path.join(self.path(), ratio_slug)
                 if os.path.exists(ratio_path):
                     shutil.rmtree(ratio_path)
@@ -443,6 +447,12 @@ class Image(models.Model):
             "id": self.id_string,
             "ratio_slug": ratio,
             "width": width,
+            "extension": format
+        })
+
+    def get_animated_url(self, format="gif"):
+        return reverse("betty.cropper.views.animated", kwargs={
+            "id": self.id_string,
             "extension": format
         })
 

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -21,6 +21,10 @@ from jsonfield import JSONField
 logger = __import__('logging').getLogger(__name__)
 
 
+ANIMATED_EXTENSIONS = ['gif', 'jpg']
+CROP_EXTENSIONS = ["png", "jpg"]
+
+
 def source_upload_to(instance, filename):
     return os.path.join(instance.path(), filename)
 
@@ -321,12 +325,12 @@ class Image(models.Model):
             for ratio_slug in ratios:
                 # Since might now know which formats to flush (since maybe not saving crops to
                 # disk), need to flush all possible crops.
-                paths += [self.get_absolute_url(ratio=ratio_slug, width=width, format=format)
-                          for format in ["png", "jpg"]
+                paths += [self.get_absolute_url(ratio=ratio_slug, width=width, extension=extension)
+                          for extension in CROP_EXTENSIONS
                           for width in settings.BETTY_WIDTHS]
             if self.animated:
-                for format in ['gif', 'jpg']:
-                    paths.append(self.get_animated_url(format=format))
+                for extension in ANIMATED_EXTENSIONS:
+                    paths.append(self.get_animated_url(extension=extension))
 
             flusher(paths)
 
@@ -442,18 +446,18 @@ class Image(models.Model):
 
         return tmp.getvalue()
 
-    def get_absolute_url(self, ratio="original", width=600, format="jpg"):
+    def get_absolute_url(self, ratio="original", width=600, extension="jpg"):
         return reverse("betty.cropper.views.crop", kwargs={
             "id": self.id_string,
             "ratio_slug": ratio,
             "width": width,
-            "extension": format
+            "extension": extension
         })
 
-    def get_animated_url(self, format="gif"):
+    def get_animated_url(self, extension="gif"):
         return reverse("betty.cropper.views.animated", kwargs={
             "id": self.id_string,
-            "extension": format
+            "extension": extension
         })
 
     def to_native(self):

--- a/betty/cropper/views.py
+++ b/betty/cropper/views.py
@@ -72,7 +72,7 @@ def redirect_crop(request, id, ratio_slug, width, extension):
     image = Image(id=image_id)
 
     return HttpResponseRedirect(image.get_absolute_url(ratio=ratio_slug, width=width,
-                                                       format=extension))
+                                                       extension=extension))
 
 
 @cache_control(max_age=settings.BETTY_CACHE_CROP_SEC)

--- a/tests/test_animated.py
+++ b/tests/test_animated.py
@@ -61,6 +61,12 @@ def test_get_not_animated(client, image):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("clean_image_root")
-def test_get_invalid_iamge(client):
+def test_get_invalid_image(client):
     res = client.get('/images/1/animated/original.gif')
     assert res.status_code == 404
+
+
+def test_get_animated_url():
+    image = Image(id=1)
+    assert '/images/1/animated/original.gif' == image.get_animated_url(format='gif')
+    assert '/images/1/animated/original.jpg' == image.get_animated_url(format='jpg')

--- a/tests/test_animated.py
+++ b/tests/test_animated.py
@@ -68,5 +68,5 @@ def test_get_invalid_image(client):
 
 def test_get_animated_url():
     image = Image(id=1)
-    assert '/images/1/animated/original.gif' == image.get_animated_url(format='gif')
-    assert '/images/1/animated/original.jpg' == image.get_animated_url(format='jpg')
+    assert '/images/1/animated/original.gif' == image.get_animated_url(extension='gif')
+    assert '/images/1/animated/original.jpg' == image.get_animated_url(extension='jpg')

--- a/tests/test_image_urls.py
+++ b/tests/test_image_urls.py
@@ -13,10 +13,10 @@ def test_image_url():
     image = Image(id=123456)
     assert image.get_absolute_url() == "/images/1234/56/original/600.jpg"
 
-    assert image.get_absolute_url(format="png") == "/images/1234/56/original/600.png"
+    assert image.get_absolute_url(extension="png") == "/images/1234/56/original/600.png"
     assert image.get_absolute_url(width=900) == "/images/1234/56/original/900.jpg"
     assert image.get_absolute_url(ratio="16x9") == "/images/1234/56/16x9/600.jpg"
-    assert image.get_absolute_url(format="png",
+    assert image.get_absolute_url(extension="png",
                                   width=900, ratio="16x9") == "/images/1234/56/16x9/900.png"
 
     image = Image(id=123)


### PR DESCRIPTION
Betty never cleared these before, adding this for completeness before we start bumping up CDN cache times.

@benghaziboy 