### PR TITLE
Alternate non-breakpoint caching duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Betty Cropper Change Log
 
+## Version 2.2.0
+
+- Allow optional alternate cache duration for non-breakpoint crop widths (i.e. width not in `settings.BETTY_WIDTHS` and
+  `settings.BETTY_CLIENT_ONLY_WIDTHS`) via new `settings.BETTY_CACHE_CROP_NON_BREAKPOINT_SEC`.
+      - This allows breakpoint-widths to set very long cache times because they will be included in the itemized cache flush callback.
+      - If `settings.BETTY_CACHE_CROP_NON_BREAKPOINT_SEC` not set, will use `settings.BETTY_CACHE_CROP_SEC`.
+
 ## Version 2.1.1
 
 - Packaging/install fix
@@ -47,7 +54,7 @@
 
 ### Upgrade Notes
 
-This new version can be dropped into an existing Betty environment, using same local disk filesystem as before, but may require a single settings change (see below). 
+This new version can be dropped into an existing Betty environment, using same local disk filesystem as before, but may require a single settings change (see below).
 
 #### FileSystemStorage (Default)
 

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"

--- a/betty/conf/app.py
+++ b/betty/conf/app.py
@@ -51,6 +51,7 @@ DEFAULTS = {
     "BETTY_SAVE_CROPS_TO_DISK": True,  # On by default (per legacy behavior)
     "BETTY_SAVE_CROPS_TO_DISK_ROOT": None,   # If not set, will use BETTY_IMAGE_ROOT
     "BETTY_CACHE_CROP_SEC": 300,
+    "BETTY_CACHE_CROP_NON_BREAKPOINT_SEC": None,  # If not set, will use BETTY_CACHE_CROP_SEC
     "BETTY_CACHE_IMAGEJS_SEC": 300,
 }
 

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -110,6 +110,53 @@ def test_image_redirect(client):
     assert res['Location'].endswith("/images/6666/66/1x1/100.jpg")
 
 
+@pytest.fixture()
+def image(request):
+    image = Image.objects.create(
+        name="Lenna.png",
+        width=512,
+        height=512
+    )
+
+    lenna = File(open(os.path.join(TEST_DATA_PATH, "Lenna.png"), "rb"))
+    image.source.save("Lenna.png", lenna)
+    return image
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_crop_caching(settings, client, image):
+
+    settings.BETTY_CACHE_CROP_SEC = 1234
+    settings.BETTY_CACHE_CROP_NON_BREAKPOINT_SEC = 456
+    settings.BETTY_WIDTHS = [100]
+    settings.BETTY_CLIENT_ONLY_WIDTHS = [200]
+
+    # Breakpoint
+    for width in [100, 200]:
+        res = client.get('/images/{image_id}/1x1/{width}.jpg'.format(image_id=image.id,
+                                                                     width=width))
+        assert res.status_code == 200
+        assert res['Cache-Control'] == 'max-age=1234'
+
+    # Non-Breakpoint
+    res = client.get('/images/{}/1x1/300.jpg'.format(image.id))
+    assert res.status_code == 200
+    assert res['Cache-Control'] == 'max-age=456'
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_crop_caching_default_non_breakpoint(settings, client, image):
+
+    settings.BETTY_CACHE_CROP_SEC = 1234
+
+    # BETTY_CACHE_CROP_NON_BREAKPOINT_SEC not set, uses BETTY_CACHE_CROP_SEC
+    res = client.get('/images/{}/1x1/100.jpg'.format(image.id))
+    assert res.status_code == 200
+    assert res['Cache-Control'] == 'max-age=1234'
+
+
 @pytest.mark.django_db
 def test_placeholder(settings, client):
     settings.BETTY_PLACEHOLDER = True
@@ -141,17 +188,14 @@ def test_missing_file(client):
         assert mock_logger.exception.call_args[0][0].startswith('Cropping error')
 
 
+def test_breakpoint_width_caching(client):
+    res = client.get('/images/abc/13x4/256.jpg')
+    assert res.status_code == 404
+
+
 @pytest.mark.django_db
 @pytest.mark.usefixtures("clean_image_root")
-def test_image_save(client):
-
-    image = Image.objects.create(
-        name="Lenna.png",
-        width=512,
-        height=512
-    )
-    lenna = File(open(os.path.join(TEST_DATA_PATH, "Lenna.png"), "rb"))
-    image.source.save("Lenna.png", lenna)
+def test_image_save(client, image):
 
     # Now let's test that a JPEG crop will return properly.
     res = client.get('/images/{}/1x1/240.jpg'.format(image.id))
@@ -180,16 +224,8 @@ def test_image_save(client):
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("clean_image_root")
-def test_disable_crop_save(client, settings):
+def test_disable_crop_save(client, settings, image):
     settings.BETTY_SAVE_CROPS_TO_DISK = False
-
-    image = Image.objects.create(
-        name="Lenna.png",
-        width=512,
-        height=512
-    )
-    lenna = File(open(os.path.join(TEST_DATA_PATH, "Lenna.png"), "rb"))
-    image.source.save("Lenna.png", lenna)
 
     # Now let's test that a JPEG crop will return properly.
     res = client.get('/images/{}/1x1/240.jpg'.format(image.id))

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -188,11 +188,6 @@ def test_missing_file(client):
         assert mock_logger.exception.call_args[0][0].startswith('Cropping error')
 
 
-def test_breakpoint_width_caching(client):
-    res = client.get('/images/abc/13x4/256.jpg')
-    assert res.status_code == 404
-
-
 @pytest.mark.django_db
 @pytest.mark.usefixtures("clean_image_root")
 def test_image_save(client, image):


### PR DESCRIPTION
Workaround for cache flush limitation that will allow us to cache most crops for very long durations (1 week+).

This change allows optional alternate cache duration for non-breakpoint widths.

This is useful b/c cache flush callback only receives paths for known breakpoints, so this allows non-standard widths to have a shorter cache time. This wouldn't be necessary if cache flush used wildcards instead, or if you could guarantee/force only defined breakpoint widths.

@benghaziboy @MichaelButkovic 
