### PR TITLE
Fix setup.py install to include requirements TXT files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Betty Cropper Change Log
 
+## Version 2.1.1
+
+- Packaging/install fix
+
 ## Version 2.1.0
 - Improvements to BETTY_CACHE_FLUSHER support:
   - `BETTY_CACHE_FLUSHER` can either be set to a callable object or a string import path

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements/*.txt

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"


### PR DESCRIPTION
Necessary since requirements were broken out into separate TXT files for easy Docker builds