### PR TITLE
Add 304/If-Modified-Since cache refresh support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added "If-Modified-Since" / 304 request header support to avoid accessing backend storage on cache re-validation.
 
+** Requires migration (add column `Image.last_modified`)**
+
 ## Version 2.2.0
 
 - Allow optional alternate cache duration for non-breakpoint crop widths (i.e. width not in `settings.BETTY_WIDTHS` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Betty Cropper Change Log
 
+## Version 2.3.0
+
+- Added "If-Modified-Since" / 304 request header support to avoid accessing backend storage on cache re-validation.
+
 ## Version 2.2.0
 
 - Allow optional alternate cache duration for non-breakpoint crop widths (i.e. width not in `settings.BETTY_WIDTHS` and

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"

--- a/betty/cropper/migrations/0002_image_last_modified.py
+++ b/betty/cropper/migrations/0002_image_last_modified.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='image',
-            name='last_updated',
+            name='last_modified',
             field=models.DateTimeField(default=timezone.now(), auto_now=True),
             preserve_default=False,
         ),

--- a/betty/cropper/migrations/0002_image_last_updated.py
+++ b/betty/cropper/migrations/0002_image_last_updated.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.utils import timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cropper', '0001_squashed_0004_auto_20160317_1706'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='image',
+            name='last_updated',
+            field=models.DateTimeField(default=timezone.now(), auto_now=True),
+            preserve_default=False,
+        ),
+    ]

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -190,7 +190,7 @@ class Image(models.Model):
     animated = models.BooleanField(default=False)
 
     # Used for "If-Modified-Since/304" handling
-    last_updated = models.DateTimeField(auto_now=True)
+    last_modified = models.DateTimeField(auto_now=True)
 
     objects = ImageManager()
 

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -189,6 +189,9 @@ class Image(models.Model):
     jpeg_quality_settings = JSONField(null=True, blank=True)
     animated = models.BooleanField(default=False)
 
+    # Used for "If-Modified-Since/304" handling
+    last_updated = models.DateTimeField(auto_now=True)
+
     objects = ImageManager()
 
     class Meta:

--- a/betty/cropper/tasks.py
+++ b/betty/cropper/tasks.py
@@ -79,5 +79,5 @@ def search_image_quality(image_id):
 
         last_width = width
 
-    image.clear_crops()
     image.save()
+    image.clear_crops()

--- a/betty/cropper/utils/__init__.py
+++ b/betty/cropper/utils/__init__.py
@@ -1,0 +1,6 @@
+import time
+
+
+# Necessary b/c Python<3.3 doesn't support datetime.timestamp()
+def seconds_since_epoch(when):
+    return int(time.mktime(when.timetuple()))

--- a/betty/cropper/utils/http.py
+++ b/betty/cropper/utils/http.py
@@ -1,0 +1,18 @@
+import time
+
+from django.utils.http import parse_http_date_safe
+
+from betty.cropper.utils import seconds_since_epoch
+
+
+def check_not_modified(request, last_modified):
+    """Handle 304/If-Modified-Since
+
+    With Django v1.9.5+ could just use "django.utils.cache.get_conditional_response", but v1.9 is
+    not supported by "logan" dependancy (yet).
+    """
+
+    if_modified_since = parse_http_date_safe(request.META.get('HTTP_IF_MODIFIED_SINCE'))
+    return (last_modified and
+            if_modified_since and
+            seconds_since_epoch(last_modified) <= if_modified_since)

--- a/betty/cropper/utils/http.py
+++ b/betty/cropper/utils/http.py
@@ -1,5 +1,3 @@
-import time
-
 from django.utils.http import parse_http_date_safe
 
 from betty.cropper.utils import seconds_since_epoch

--- a/betty/cropper/views.py
+++ b/betty/cropper/views.py
@@ -5,12 +5,13 @@ from django.http import (Http404, HttpResponse, HttpResponseNotModified,
                          HttpResponseServerError, HttpResponseRedirect)
 from django.shortcuts import render
 from django.utils.cache import patch_cache_control
-from django.utils.http import parse_http_date_safe
+from django.utils.http import http_date
 
 from django.views.decorators.cache import cache_control
 from six.moves import urllib
 
 from .models import Image, Ratio
+from .utils.http import check_not_modified
 from .utils.placeholder import placeholder
 
 logger = __import__('logging').getLogger(__name__)
@@ -30,17 +31,6 @@ EXTENSION_MAP = {
         "mime_type": "image/png"
     },
 }
-
-
-def check_not_modified(request, last_modified):
-    """Handle 304/If-Modified-Since
-
-    With Django v1.9.5+ could just use get_conditional_response, but v1.9 is not
-    supported by "logan" dependancy (yet).
-    """
-    logger.debug('HEADERS: %s', request.META.items())  # TEMP TESTING TO MAKE SURE RIGHT HEADERS
-    if_modified_since = parse_http_date_safe(request.META.get('HTTP_IF_MODIFIED_SINCE'))
-    return last_modified and if_modified_since and last_modified <= if_modified_since
 
 
 @cache_control(max_age=settings.BETTY_CACHE_IMAGEJS_SEC)
@@ -90,6 +80,13 @@ def redirect_crop(request, id, ratio_slug, width, extension):
                                                        extension=extension))
 
 
+def _image_response(image_blob, extension):
+    resp = HttpResponse(image_blob)
+    resp["Content-Type"] = EXTENSION_MAP[extension]["mime_type"]
+    resp['Last-Modified'] = http_date()
+    return resp
+
+
 def crop(request, id, ratio_slug, width, extension):
     if ratio_slug != "original" and ratio_slug not in settings.BETTY_RATIOS:
         raise Http404
@@ -120,7 +117,7 @@ def crop(request, id, ratio_slug, width, extension):
         else:
             raise Http404
 
-    if check_not_modified(request=request, last_modified=image.last_updated):
+    if check_not_modified(request=request, last_modified=image.last_modified):
         # Avoid hitting storage backend on cache update
         resp = HttpResponseNotModified()
     else:
@@ -130,8 +127,7 @@ def crop(request, id, ratio_slug, width, extension):
             logger.exception("Cropping error")
             return HttpResponseServerError("Cropping error")
 
-        resp = HttpResponse(image_blob)
-        resp["Content-Type"] = EXTENSION_MAP[extension]["mime_type"]
+        resp = _image_response(image_blob, extension=extension)
 
     # Optionally specify alternate cache duration for non-breakpoint widths.
     # This is useful b/c cache flush callback only receives paths for known breakpoints, so this
@@ -147,7 +143,6 @@ def crop(request, id, ratio_slug, width, extension):
 
 # Legacy behavior -- originally these were just dropped on filesystem and let NGINX frontend serve
 # automatically via try-files.
-@cache_control(max_age=settings.BETTY_CACHE_CROP_SEC)
 def animated(request, id, extension):
 
     image_id = int(id.replace("/", ""))
@@ -160,9 +155,9 @@ def animated(request, id, extension):
     if not image.animated:
         raise Http404
 
-    if check_not_modified(request=request, last_modified=image.last_updated):
+    if check_not_modified(request=request, last_modified=image.last_modified):
         # Avoid hitting storage backend on cache update
-        return HttpResponseNotModified()
+        resp = HttpResponseNotModified()
     else:
         try:
             image_blob = image.get_animated(extension=extension)
@@ -170,6 +165,7 @@ def animated(request, id, extension):
             logger.exception("Animated error")
             return HttpResponseServerError("Animated error")
 
-        resp = HttpResponse(image_blob)
-        resp["Content-Type"] = EXTENSION_MAP[extension]["mime_type"]
-        return resp
+        resp = _image_response(image_blob, extension=extension)
+
+    patch_cache_control(resp, max_age=settings.BETTY_CACHE_CROP_SEC)
+    return resp

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,4 @@ psutil==2.2.1
 dj-inmemorystorage==1.4.0
 ipython==4.1.1
 ipdb==0.8.1
+freezegun==0.3.7

--- a/tests/test_animated.py
+++ b/tests/test_animated.py
@@ -1,5 +1,6 @@
 import os
 
+from freezegun import freeze_time
 import pytest
 
 from django.core.files import File
@@ -23,12 +24,14 @@ def image(request):
     return image
 
 
+@freeze_time('2016-05-02 01:02:03')
 @pytest.mark.django_db
 @pytest.mark.usefixtures("clean_image_root")
 def test_get_jpg(client, image):
     res = client.get('/images/{}/animated/original.jpg'.format(image.id))
     assert res.status_code == 200
     assert res['Content-Type'] == 'image/jpeg'
+    assert res['Last-Modified'] == "Mon, 02 May 2016 01:02:03 GMT"
     saved_path = os.path.join(image.path(), 'animated/original.jpg')
     assert os.path.exists(saved_path)
 
@@ -70,3 +73,14 @@ def test_get_animated_url():
     image = Image(id=1)
     assert '/images/1/animated/original.gif' == image.get_animated_url(extension='gif')
     assert '/images/1/animated/original.jpg' == image.get_animated_url(extension='jpg')
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_if_modified_since(settings, client, image):
+    settings.BETTY_CACHE_CROP_SEC = 600
+    res = client.get('/images/{}/animated/original.gif'.format(image.id),
+                     HTTP_IF_MODIFIED_SINCE="Sat, 01 May 2100 00:00:00 GMT")
+    assert res.status_code == 304
+    assert res['Cache-Control'] == 'max-age=600'
+    assert not res.content  # Empty content

--- a/tests/test_crop_utils.py
+++ b/tests/test_crop_utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.http import HttpRequest
 from django.utils import timezone
@@ -26,8 +26,9 @@ def test_check_not_modified_has_if_modified_since_header():
     # Fails if "last_modified" invalid
     assert not check_not_modified(request, None)
     # Before
-    assert check_not_modified(request, datetime(1994, 11, 6, 8, 49, 36, tzinfo=timezone.utc))
+    when = datetime(1994, 11, 6, 8, 49, 37, tzinfo=timezone.utc)
+    assert check_not_modified(request, when - timedelta(seconds=1))
     # Identical
-    assert check_not_modified(request, datetime(1994, 11, 6, 8, 49, 37, tzinfo=timezone.utc))
+    assert check_not_modified(request, when)
     # After
-    assert not check_not_modified(request, datetime(1994, 11, 6, 8, 49, 38, tzinfo=timezone.utc))
+    assert not check_not_modified(request, when + timedelta(seconds=1))

--- a/tests/test_crop_utils.py
+++ b/tests/test_crop_utils.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from django.http import HttpRequest
+from django.utils import timezone
+
+from betty.cropper.utils import seconds_since_epoch
+from betty.cropper.utils.http import check_not_modified
+
+
+def test_seconds_since_epoch():
+    return 0 == seconds_since_epoch(datetime(1970, 1, 1))
+    return 1462218127 == seconds_since_epoch(datetime(2016, 5, 2, 19, 42, 7))
+
+
+def test_check_not_modified_missing_header():
+    request = HttpRequest()
+    # Never succeeds if missing "If-Modified-Since" header
+    assert not check_not_modified(request, None)
+    assert not check_not_modified(request, timezone.now())
+    assert not check_not_modified(request, datetime(1994, 11, 6, tzinfo=timezone.utc))
+
+
+def test_check_not_modified_has_if_modified_since_header():
+    request = HttpRequest()
+    request.META['HTTP_IF_MODIFIED_SINCE'] = "Sun, 06 Nov 1994 08:49:37 GMT"
+    # Fails if "last_modified" invalid
+    assert not check_not_modified(request, None)
+    # Before
+    assert check_not_modified(request, datetime(1994, 11, 6, 8, 49, 36, tzinfo=timezone.utc))
+    # Identical
+    assert check_not_modified(request, datetime(1994, 11, 6, 8, 49, 37, tzinfo=timezone.utc))
+    # After
+    assert not check_not_modified(request, datetime(1994, 11, 6, 8, 49, 38, tzinfo=timezone.utc))

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -1,5 +1,6 @@
 import os
 
+from freezegun import freeze_time
 import pytest
 
 from django.core.files import File
@@ -11,6 +12,17 @@ from mock import patch
 
 
 TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'images')
+
+
+@freeze_time('2016-05-02 01:02:03')
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_basic_cropping(settings, client, image):
+    settings.BETTY_CACHE_CROP_SEC = 600
+    res = client.get('/images/{}/1x1/200.jpg'.format(image.id))
+    assert res.status_code == 200
+    assert res['Cache-Control'] == 'max-age=600'
+    assert res['Last-Modified'] == "Mon, 02 May 2016 01:02:03 GMT"
 
 
 @pytest.mark.django_db
@@ -273,3 +285,14 @@ def test_image_js_use_request_host(settings, client):
     res = client.get("/images/image.js", SERVER_NAME='alt.example.org')
     assert res.status_code == 200
     assert res.context['BETTY_IMAGE_URL'] == '//alt.example.org/images'
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_if_modified_since(settings, client, image):
+    settings.BETTY_CACHE_CROP_SEC = 600
+    res = client.get('/images/{}/1x1/300.jpg'.format(image.id),
+                     HTTP_IF_MODIFIED_SINCE="Sat, 01 May 2100 00:00:00 GMT")
+    assert res.status_code == 304
+    assert res['Cache-Control'] == 'max-age=600'
+    assert not res.content  # Empty content

--- a/tests/test_cropping.py
+++ b/tests/test_cropping.py
@@ -1,6 +1,8 @@
+import io
 import os
 
 from freezegun import freeze_time
+from PIL import Image as PILImage
 import pytest
 
 from django.core.files import File
@@ -23,6 +25,11 @@ def test_basic_cropping(settings, client, image):
     assert res.status_code == 200
     assert res['Cache-Control'] == 'max-age=600'
     assert res['Last-Modified'] == "Mon, 02 May 2016 01:02:03 GMT"
+    assert res['Content-Type'] == "image/jpeg"
+
+    image_buffer = io.BytesIO(res.content)
+    img = PILImage.open(image_buffer)
+    assert img.size == (200, 200)
 
 
 @pytest.mark.django_db

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -1,9 +1,11 @@
 import os
 
+from freezegun import freeze_time
 from mock import call, patch
 import pytest
 
 from django.core.files import File
+from django.utils import timezone
 
 from betty.cropper.models import Image, Ratio
 
@@ -127,3 +129,14 @@ def test_refresh_dimensions(image):
         image._refresh_dimensions()
         assert image.width == 512
         assert image.get_width() == 512
+
+
+@freeze_time('2016-05-02 01:02:03')
+@pytest.mark.django_db
+def test_last_modified_auto_now(image):
+    assert image.last_modified == timezone.datetime(2016, 5, 2, 1, 2, 3, tzinfo=timezone.utc)
+
+    with freeze_time('2016-12-02 01:02:03'):
+        image.save()
+
+    assert image.last_modified == timezone.datetime(2016, 12, 2, 1, 2, 3, tzinfo=timezone.utc)

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -131,12 +131,16 @@ def test_refresh_dimensions(image):
         assert image.get_width() == 512
 
 
-@freeze_time('2016-05-02 01:02:03')
 @pytest.mark.django_db
-def test_last_modified_auto_now(image):
+def test_last_modified_auto_now():
+    with freeze_time('2016-05-02 01:02:03'):
+        image = Image.objects.create(
+            name="Lenna.gif",
+            width=512,
+            height=512
+        )
     assert image.last_modified == timezone.datetime(2016, 5, 2, 1, 2, 3, tzinfo=timezone.utc)
 
     with freeze_time('2016-12-02 01:02:03'):
         image.save()
-
     assert image.last_modified == timezone.datetime(2016, 12, 2, 1, 2, 3, tzinfo=timezone.utc)


### PR DESCRIPTION
Major efficiency gain by supporting "If-Modified-Since" request header to avoid hitting storage backend.

This is especially important when using non-disk storage like S3, and eventually disabling on-disk saved crops (served by NGINX). 

- [x] Implement 304 handling
- [x] Unit tests
