### PR TITLE
Migrate legacy relative disk paths to absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Betty Cropper Change Log
 
+## Version 2.4.0
+
+- Added management command `make_disk_storage_paths_absolute` to convert legacy relative disk paths to absolute paths.
+
 ## Version 2.3.1
 
 - Fix: Cache flush callback now also includes CLIENT_ONLY_WIDTHS

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"

--- a/betty/cropper/management/commands/make_disk_storage_paths_absolute.py
+++ b/betty/cropper/management/commands/make_disk_storage_paths_absolute.py
@@ -25,10 +25,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        for idx, image in enumerate(Image.objects.iterator()):
+        for idx, image in enumerate(Image.objects.order_by('pk').iterator()):
 
-            if options['limit'] and idx > options['limit']:
+            if options['limit'] and idx >= options['limit']:
                 self.stdout.write('Early exit (limit %s reached)'.format(options['limit']))
+                break
 
             for field in [image.source,
                           image.optimized]:
@@ -38,8 +39,9 @@ class Command(BaseCommand):
 
                         path = os.path.join(settings.MEDIA_ROOT, field.name)
 
-                        self.stdout.write(u'{}{} --> {}'.format(
+                        self.stdout.write(u'{}{}\t{} --> {}'.format(
                             '[CHECK] ' if options['check'] else '',
+                            image.id,
                             field.name,
                             path))
 

--- a/betty/cropper/management/commands/make_disk_storage_paths_absolute.py
+++ b/betty/cropper/management/commands/make_disk_storage_paths_absolute.py
@@ -48,10 +48,11 @@ class Command(BaseCommand):
                         # Sanity checks
                         assert os.path.exists(path)
                         assert path.startswith(settings.MEDIA_ROOT)
+                        assert path.endswith(field.name)
                         assert '//' not in path, "Guard against weird path joins"
 
                         if not options['check']:
                             field.name = path
                             image.save()
                     else:
-                        self.stdout.write('SKIP: %s', field.name)
+                        self.stdout.write('SKIP: {} {}'.format(image.id, field.name))

--- a/betty/cropper/management/commands/make_disk_storage_paths_absolute.py
+++ b/betty/cropper/management/commands/make_disk_storage_paths_absolute.py
@@ -1,0 +1,55 @@
+from optparse import make_option
+import os.path
+
+from betty.conf.app import settings
+from django.core.management.base import BaseCommand
+
+from betty.cropper.models import Image
+
+
+class Command(BaseCommand):
+    help = 'Convert disk storage relative paths to absolute'
+
+    # This needs to run on Django 1.7
+    option_list = BaseCommand.option_list + (
+        make_option('--check',
+                    action='store_true',
+                    dest='check',
+                    default=False,
+                    help='Dry-run (read-only) check mode'),
+        make_option('--limit',
+                    type=int,
+                    dest='limit',
+                    help='Maximum number of images to process'),
+    )
+
+    def handle(self, *args, **options):
+
+        for idx, image in enumerate(Image.objects.iterator()):
+
+            if options['limit'] and idx > options['limit']:
+                self.stdout.write('Early exit (limit %s reached)'.format(options['limit']))
+
+            for field in [image.source,
+                          image.optimized]:
+
+                if field.name:
+                    if not field.name.startswith(settings.MEDIA_ROOT):
+
+                        path = os.path.join(settings.MEDIA_ROOT, field.name)
+
+                        self.stdout.write(u'{}{} --> {}'.format(
+                            '[CHECK] ' if options['check'] else '',
+                            field.name,
+                            path))
+
+                        # Sanity checks
+                        assert os.path.exists(path)
+                        assert path.startswith(settings.MEDIA_ROOT)
+                        assert '//' not in path, "Guard against weird path joins"
+
+                        if not options['check']:
+                            field.name = path
+                            image.save()
+                    else:
+                        self.stdout.write('SKIP: %s', field.name)


### PR DESCRIPTION
I ran into a surprise this morning while migrating Onion disk storage to S3. The migration steps assumed that all image paths were absolute (`/var/betty-cropper/1000/2/some_other_image.jpg`) but older Onion image paths were relative (`1000/1/some_image.jpg`).

I didn't run into this for other property migrations because these relative paths are only used by legacy Onion (pre-April 2015) and AVC (pre-Mar 2014) images. 

This converts all relative image paths to absolute. Once this script is run to fix legacy paths, we can resume S3 migration.

@benghaziboy @MichaelButkovic @spra85 