### PR TITLE
Prevent image.js from computing "undefined" aspect ratio in rare edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Betty Cropper Change Log
 
+## Version 2.4.1
+
+- Fix `image.js` function `computeAspectRatio` to always return a valid ratio. Previously there was an edge case where it would
+  return `undefined`, resulting in a bad image URL.
+
 ## Version 2.4.0
 
 - Added management command `make_disk_storage_paths_absolute` to convert legacy relative disk paths to absolute paths.

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/betty/cropper/templates/image.js
+++ b/betty/cropper/templates/image.js
@@ -68,7 +68,7 @@
 
       // this is a div to picturefill, start working on it if it hasn't been rendered yet
       if (el.getAttribute("data-image-id") !== null
-          && visible 
+          && visible
           && (forceRerender || !el.getAttribute("data-rendered"))) {
         var imageContainer = el.getElementsByTagName("div")[0],
             imageId = el.getAttribute("data-image-id"),
@@ -193,9 +193,9 @@
           return RATIOS[i][0];
         }
       }
-    } else {
-      return "16x9";
     }
+    // No suitable ratio, use default.
+    return "16x9";
   }
 
   function addEventListener(ele, event, callback) {


### PR DESCRIPTION
@kand @MichaelButkovic @benghaziboy 

Tightens up `images.js` aspect ratio computation.

Potential fix for production spike in 404s across all sites. I can't reproduce locally but it appears to be related to recirc sidebar images via `image.js`. 