### PR TITLE
Image caching uses "source-images" cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Betty Cropper Change Log
 
-## Version 2.5.0
+## Version 2.5.1
+
+- Image source caching attempts to use named cache "source-images", else "default".
+
+## Version 2.5.1
 
 - Add storage caching layer (ex: memcached in front of S3 backend) to improve performance with slower storage backends.
   Cache time controlled by new `BETTY_CACHE_STORAGE_SEC` setting (default: 1 hour).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Image source caching attempts to use named cache "source-images", else "default".
 
-## Version 2.5.1
+## Version 2.5.0
 
 - Add storage caching layer (ex: memcached in front of S3 backend) to improve performance with slower storage backends.
   Cache time controlled by new `BETTY_CACHE_STORAGE_SEC` setting (default: 1 hour).

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -3,7 +3,8 @@ import io
 import os
 import shutil
 
-from django.core.cache import cache
+from django.core.cache import cache as default_cache, caches
+from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.files import File
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -171,6 +172,12 @@ def _read_from_storage(file_field):
     """
 
     if file_field:
+
+        try:
+            cache = caches['source-images']
+        except InvalidCacheBackendError:
+            cache = default_cache
+
         cache_key = ':'.join(['storage', file_field.name])
 
         raw_image = cache.get(cache_key)


### PR DESCRIPTION
Allows image cache to use alternative backend (like filesystem) instead of typical "memcached" default. 

Will fallback to "default". 

@MichaelButkovic 