### PR TITLE
Fix `Image.clear_crops` to use correct "save to disk" path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Betty Cropper Change Log
 
+## Version 2.5.3
+
+- Fix `Image.clear_crops()` to handle when save crops path is different than image source path
+
 ## Version 2.5.2
 
 - Image source caching attempts to use named cache "storage", else "default".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.5.3
 
-- Fix `Image.clear_crops()` to handle when save crops path is different than image source path
+- Fix `Image.clear_crops()` to handle when save crops path is different than image source path. Previously was preventing saved-to-disk crops from being deleted.
 
 ## Version 2.5.2
 

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.5.2"
+__version__ = "2.5.3"

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -361,7 +361,8 @@ class Image(models.Model):
         # Optional disk crops support
         if settings.BETTY_SAVE_CROPS_TO_DISK:
             for ratio_slug in (ratios + ['animated']):
-                ratio_path = os.path.join(self.path(), ratio_slug)
+                ratio_path = os.path.join(self.path(settings.BETTY_SAVE_CROPS_TO_DISK_ROOT),
+                                          ratio_slug)
                 if os.path.exists(ratio_path):
                     shutil.rmtree(ratio_path)
 

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -43,11 +43,10 @@ def make_some_crops(image, settings):
 @pytest.mark.parametrize('save_crops', [True, False])  # Test setting enabled + disabled
 def test_image_clear_crops(image, settings, save_crops):
 
-    local_crop_path = os.path.join(settings.BETTY_IMAGE_ROOT, 'local', 'crops')
-
     settings.BETTY_SAVE_CROPS_TO_DISK = save_crops
-    settings.BETTY_SAVE_CROPS_TO_DISK_ROOT = local_crop_path  # Different than source path
-
+    # Different than source path
+    settings.BETTY_SAVE_CROPS_TO_DISK_ROOT = os.path.join(settings.BETTY_IMAGE_ROOT,
+                                                          'local', 'crops')
     make_some_crops(image, settings)
 
     with patch('betty.cropper.models.settings.BETTY_CACHE_FLUSHER') as mock_flusher:
@@ -68,7 +67,7 @@ def test_image_clear_crops(image, settings, save_crops):
             assert mock_rmtree.called == save_crops
             if save_crops:
                 # Filesystem deletes entire directories if they exist
-                image_dir = os.path.join(local_crop_path, str(image.id))
+                image_dir = os.path.join(settings.BETTY_SAVE_CROPS_TO_DISK_ROOT, str(image.id))
                 assert sorted(mock_rmtree.call_args_list) == sorted(
                     [call(os.path.join(image_dir, '1x1')),
                      call(os.path.join(image_dir, '16x9'))])

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -43,7 +43,10 @@ def make_some_crops(image, settings):
 @pytest.mark.parametrize('save_crops', [True, False])  # Test setting enabled + disabled
 def test_image_clear_crops(image, settings, save_crops):
 
+    local_crop_path = os.path.join(settings.BETTY_IMAGE_ROOT, 'local', 'crops')
+
     settings.BETTY_SAVE_CROPS_TO_DISK = save_crops
+    settings.BETTY_SAVE_CROPS_TO_DISK_ROOT = local_crop_path  # Different than source path
 
     make_some_crops(image, settings)
 
@@ -65,7 +68,7 @@ def test_image_clear_crops(image, settings, save_crops):
             assert mock_rmtree.called == save_crops
             if save_crops:
                 # Filesystem deletes entire directories if they exist
-                image_dir = os.path.join(settings.BETTY_IMAGE_ROOT, str(image.id))
+                image_dir = os.path.join(local_crop_path, str(image.id))
                 assert sorted(mock_rmtree.call_args_list) == sorted(
                     [call(os.path.join(image_dir, '1x1')),
                      call(os.path.join(image_dir, '16x9'))])


### PR DESCRIPTION
Was preventing stale on-disk crops from being deleted when source path root (S3) different than save-to-disk path ("/var/betty-cropper"). 

Will fix AVC "black image crop" bugs. 

@benghaziboy @MichaelButkovic 