### PR TITLE
Fix image caching race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Betty Cropper Change Log
 
+## Version 2.5.5
+
+- Fix image metadata caching race conditions
+
 ## Version 2.5.4
 
 - Make best effort to load corrupt images via Pillow's `ImageFile.LOAD_TRUNCATED_IMAGES` setting.

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.5.4"
+__version__ = "2.5.5"

--- a/betty/cropper/api/views.py
+++ b/betty/cropper/api/views.py
@@ -141,8 +141,9 @@ def detail(request, image_id):
             message = json.dumps({"message": "No such image!"})
             return HttpResponseNotFound(message, content_type="application/json")
 
+        cache_key = image.cache_key()
         image.delete()
-        cache.delete(image.cache_key())
+        cache.delete(cache_key)
 
         return HttpResponse(json.dumps({"message": "OK"}), content_type="application/json")
 

--- a/betty/cropper/api/views.py
+++ b/betty/cropper/api/views.py
@@ -101,8 +101,8 @@ def update_selection(request, image_id, ratio_slug):
         image.selections = {}
 
     image.selections[ratio_slug] = selection
-    cache.delete(image.cache_key())
     image.save()
+    cache.delete(image.cache_key())
 
     image.clear_crops(ratios=[ratio_slug])
 
@@ -141,8 +141,8 @@ def detail(request, image_id):
             message = json.dumps({"message": "No such image!"})
             return HttpResponseNotFound(message, content_type="application/json")
 
-        cache.delete(image.cache_key())
         image.delete()
+        cache.delete(image.cache_key())
 
         return HttpResponse(json.dumps({"message": "OK"}), content_type="application/json")
 
@@ -164,8 +164,8 @@ def detail(request, image_id):
         for field in ("name", "credit", "selections"):
             if field in request_json:
                 setattr(image, field, request_json[field])
-        cache.delete(image.cache_key())
         image.save()
+        cache.delete(image.cache_key())
 
         return HttpResponse(json.dumps(image.to_native()), content_type="application/json")
 


### PR DESCRIPTION
Last few months, AVC Editorial has had several issues where crop editor (memcached) does not match actual preview/article crops (database).

Somehow memcached (custom crops) is getting out of sync with database (default crops).

Possible that browser behavior changed slightly, exposing these race conditions? 

There still might be another problem lurking (CMS or betty), but this will at least keep memcached + database synced.