### PR TITLE
Add route to get original image asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Betty Cropper Change Log
 
+## Version 2.6.0
+
+- Add new '/<IMAGE ID>/source' route to obtain original source asset. Image format specified in 'Content-Type' response
+  header.
+
 ## Version 2.5.5
 
 - Fix image metadata caching race conditions

--- a/betty/__init__.py
+++ b/betty/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 
 from .celery import app as celery_app  # noqa
 
-__version__ = "2.5.5"
+__version__ = "2.6.0"

--- a/betty/cropper/models.py
+++ b/betty/cropper/models.py
@@ -392,6 +392,14 @@ class Image(models.Model):
             root = settings.BETTY_IMAGE_ROOT
         return os.path.join(root, id_string[1:])
 
+    def get_source(self):
+        image_bytes = self.read_source_bytes()
+
+        # Detect format
+        img = PILImage.open(image_bytes)
+
+        return image_bytes.getvalue(), img.format.lower()
+
     def get_animated(self, extension):
         """Legacy (Pre-v2.0) animated behavior.
         Originally betty just wrote these to disk on image creation and let NGINX try-files

--- a/betty/cropper/urls.py
+++ b/betty/cropper/urls.py
@@ -9,5 +9,7 @@ urlpatterns = patterns(
         'crop'),
     url(r'^(?P<id>[0-9/]+)/animated/original\.(?P<extension>(jpg|gif))$',
         'animated'),
+    url(r'^(?P<id>[0-9/]+)/source$',
+        'source'),
     url(r'^api/', include("betty.cropper.api.urls")),
 )

--- a/betty/cropper/views.py
+++ b/betty/cropper/views.py
@@ -85,6 +85,7 @@ def redirect_crop(request, id, ratio_slug, width, extension):
 def _image_response(image_blob, image_format=None, extension=None):
     resp = HttpResponse(image_blob)
 
+    # Legacy betty cropper keys off of file extension, but some newer routes auto-detect format
     if extension:
         image_format = EXTENSION_MAP[extension]['format']
     resp["Content-Type"] = FORMAT_TO_MIME_TYPE_MAP[image_format]

--- a/betty/cropper/views.py
+++ b/betty/cropper/views.py
@@ -32,6 +32,8 @@ EXTENSION_MAP = {
     },
 }
 
+FORMAT_TO_MIME_TYPE_MAP = {f['format']: f['mime_type'] for f in EXTENSION_MAP.values()}
+
 
 @cache_control(max_age=settings.BETTY_CACHE_IMAGEJS_SEC)
 def image_js(request):
@@ -80,9 +82,13 @@ def redirect_crop(request, id, ratio_slug, width, extension):
                                                        extension=extension))
 
 
-def _image_response(image_blob, extension):
+def _image_response(image_blob, image_format=None, extension=None):
     resp = HttpResponse(image_blob)
-    resp["Content-Type"] = EXTENSION_MAP[extension]["mime_type"]
+
+    if extension:
+        image_format = EXTENSION_MAP[extension]['format']
+    resp["Content-Type"] = FORMAT_TO_MIME_TYPE_MAP[image_format]
+
     resp['Last-Modified'] = http_date()
     return resp
 
@@ -138,6 +144,32 @@ def crop(request, id, ratio_slug, width, extension):
         if width not in (settings.BETTY_WIDTHS + settings.BETTY_CLIENT_ONLY_WIDTHS):
             max_age = settings.BETTY_CACHE_CROP_NON_BREAKPOINT_SEC
     patch_cache_control(resp, max_age=max_age)
+    return resp
+
+
+# Get original source asset
+def source(request, id):
+
+    image_id = int(id.replace("/", ""))
+
+    try:
+        image = Image.objects.get(id=image_id)
+    except Image.DoesNotExist:
+        raise Http404
+
+    if check_not_modified(request=request, last_modified=image.last_modified):
+        # Avoid hitting storage backend on cache update
+        resp = HttpResponseNotModified()
+    else:
+        try:
+            image_blob, image_format = image.get_source()
+        except Exception:
+            logger.exception("Source error")
+            return HttpResponseServerError("Source error")
+
+        resp = _image_response(image_blob, image_format=image_format)
+
+    patch_cache_control(resp, max_age=settings.BETTY_CACHE_CROP_SEC)
     return resp
 
 

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -181,3 +181,24 @@ def test_read_from_storage_cache(image, settings):
             assert image.read_source_bytes().getvalue() == expected_bytes
             assert 2 == mock_read.call_count
             assert cache.get(cache_key) == expected_bytes
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+@pytest.mark.parametrize(['test_name', 'test_format'],
+                         # All supported formats
+                         [('Lenna.png', 'png'),
+                          ('animated.gif', 'gif'),
+                          ('Simpsons-Week_a.jpg', 'jpeg')])
+def test_get_source_image(image, test_name, test_format):
+
+    test_path = os.path.join(TEST_DATA_PATH, test_name)
+
+    image = Image.objects.create_from_path(test_path)
+
+    image_bytes, image_format = image.get_source()
+
+    assert image_format == test_format
+
+    with open(test_path, "rb") as image:
+        assert image.read() == image_bytes

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,56 @@
+import os
+
+from freezegun import freeze_time
+import pytest
+
+from django.core.files import File
+
+from betty.cropper.models import Image
+
+TEST_DATA_PATH = os.path.join(os.path.dirname(__file__), 'images')
+
+
+@pytest.fixture()
+def image(request):
+    image = Image.objects.create(
+        name="Lenna.png",
+        width=512,
+        height=512
+    )
+
+    lenna = File(open(os.path.join(TEST_DATA_PATH, "Lenna.png"), "rb"))
+    image.source.save("Lenna.png", lenna)
+    return image
+
+
+@freeze_time('2016-05-02 01:02:03')
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_get_png(settings, client, image):
+
+    settings.BETTY_CACHE_CROP_SEC = 123
+
+    res = client.get('/images/{}/source'.format(image.id))
+    assert res.status_code == 200
+    assert res['Content-Type'] == 'image/png'
+    assert res['Last-Modified'] == "Mon, 02 May 2016 01:02:03 GMT"
+    assert res['Cache-Control'] == 'max-age=123'
+    with open(os.path.join(TEST_DATA_PATH, "Lenna.png"), "rb") as lenna:
+        assert res.content == lenna.read()
+
+
+@pytest.mark.django_db
+def test_get_invalid_image(client):
+    res = client.get('/images/1/source')
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("clean_image_root")
+def test_if_modified_since(settings, client, image):
+    settings.BETTY_CACHE_CROP_SEC = 600
+    res = client.get('/images/{}/source'.format(image.id),
+                     HTTP_IF_MODIFIED_SINCE="Sat, 01 May 2100 00:00:00 GMT")
+    assert res.status_code == 304
+    assert res['Cache-Control'] == 'max-age=600'
+    assert not res.content  # Empty content


### PR DESCRIPTION
Be free!

The intended use case is for exporting images to another platform (perhaps Kinja!). 

Previous workarounds (width from API, then request `original` aspect at provided width) resulted in impure images that were anti-aliased, as well as possibly color-converted and stretched by 1 pixels or so. 

Note: Original filename, caption, credits, etc. can still be obtained via usual API calls. Did not want to expose those through public interface, especially source filename (those may not be scrubbed/appropriate for public eyes). 