### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/theonion/betty-cropper.svg?branch=master)](https://travis-ci.org/theonion/betty-cropper)
 [![Coverage Status](https://coveralls.io/repos/theonion/betty-cropper/badge.svg?branch=master)](https://coveralls.io/r/theonion/betty-cropper?branch=master)
-[![Latest Version](https://pypip.in/version/betty-cropper/badge.svg)](https://pypi.python.org/pypi/betty-cropper/)
+[![Latest Version](https://img.shields.io/pypi/v/betty-cropper.svg)](https://pypi.python.org/pypi/betty-cropper/)
 
 ## Get started developing:
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20betty-cropper))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `betty-cropper`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.